### PR TITLE
Noted that committers modeled as GitHub team

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -10,3 +10,7 @@ Christian Murphy (@ChristianMurphy)
 * Chris Beach (@cbeach47)
 * Christian Murphy (@ChristianMurphy)
 * Drew Wills (@DrewWills)
+
+(Modeled as [a GitHub Team][uportal-web-components-committers] with `Admin` on the `uPortal-contrib/uPortal-web-components` repo.)
+
+[uportal-web-components-committers]: https://github.com/orgs/uPortal-contrib/teams/uportal-web-components-committers


### PR DESCRIPTION
Documents that Committers modeled as specific team, 
which may help remind on future committer add to also update the team.