### PR TITLE
Build: vue browserslist fix

### DIFF
--- a/@uportal/content-carousel/package.json
+++ b/@uportal/content-carousel/package.json
@@ -21,15 +21,10 @@
     "vue-template-compiler": "^2.5.16"
   },
   "babel": {
-    "presets": [
-      "@vue/app"
-    ]
+    "presets": ["@vue/app"]
   },
   "eslintConfig": {
-    "extends": [
-      "plugin:vue/essential",
-      "@vue/prettier"
-    ],
+    "extends": ["plugin:vue/essential", "@vue/prettier"],
     "root": true,
     "env": {
       "node": true
@@ -44,10 +39,7 @@
       "autoprefixer": {}
     }
   },
-  "browserslist": [
-    "> 1%",
-    "not dead"
-  ],
+  "browserslist": ["> 1%", "not ie < 11"],
   "publishConfig": {
     "access": "public"
   },
@@ -57,14 +49,7 @@
   },
   "license": "Apache-2.0",
   "author": "Apereo <uportal-dev@apereo.org>",
-  "keywords": [
-    "apereo",
-    "uportal",
-    "content",
-    "carousel",
-    "browse",
-    "list"
-  ],
+  "keywords": ["apereo", "uportal", "content", "carousel", "browse", "list"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/uPortal-contrib/uPortal-web-components.git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][]
 
+### Fix
+
+* **content-carousel**: Ensure `browserslist` support query can be handled by Vue CLI service.
+
 ## [1.0.0][]
 
 ### Documentation


### PR DESCRIPTION
Resolves warning 'browser dead is not recognized', this query will be supported in a later version of vue/babel.