### PR TITLE
fix(open-id-connect): do not embed polyfills with script

### DIFF
--- a/@uportal/open-id-connect/.babelrc
+++ b/@uportal/open-id-connect/.babelrc
@@ -5,7 +5,6 @@
         [
           "@babel/preset-env",
           {
-            "useBuiltIns": "usage",
             "targets": {
               "browsers": ["last 2 versions", "not dead"],
               "node": "6"
@@ -20,7 +19,6 @@
         [
           "@babel/preset-env",
           {
-            "useBuiltIns": "usage",
             "targets": {
               "browsers": ["last 2 versions", "not dead"],
               "node": "6"
@@ -35,7 +33,6 @@
         [
           "@babel/preset-env",
           {
-            "useBuiltIns": "usage",
             "targets": {
               "browsers": ["last 2 versions", "not dead"],
               "node": "6"
@@ -50,7 +47,6 @@
         [
           "@babel/preset-env",
           {
-            "useBuiltIns": "usage",
             "targets": {
               "browsers": ["last 2 versions", "not dead"],
               "node": "6"

--- a/@uportal/open-id-connect/package-lock.json
+++ b/@uportal/open-id-connect/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@uportal/open-id-connect",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/cli": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.49.tgz",
-      "integrity": "sha1-yMMTX3vEhChDb69ePydCJ6me8qg=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.53.tgz",
+      "integrity": "sha1-8srwmVAiQSOEXsUHfterCGPY2CM=",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.3",
@@ -16,33 +16,34 @@
         "fs-readdir-recursive": "^1.0.0",
         "glob": "^7.0.0",
         "lodash": "^4.17.5",
+        "mkdirp": "^0.5.1",
         "output-file-sync": "^2.0.0",
         "slash": "^1.0.0",
         "source-map": "^0.5.0"
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-      "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+      "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.49"
+        "@babel/highlight": "7.0.0-beta.53"
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.49.tgz",
-      "integrity": "sha1-c94ggd1lJIlInwy0qpeCmhEzMU4=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.53.tgz",
+      "integrity": "sha1-q2R8+7JyQf0i7DyhNC161Oa1T58=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/helpers": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/code-frame": "7.0.0-beta.53",
+        "@babel/generator": "7.0.0-beta.53",
+        "@babel/helpers": "7.0.0-beta.53",
+        "@babel/parser": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
         "convert-source-map": "^1.1.0",
         "debug": "^3.1.0",
         "json5": "^0.5.0",
@@ -77,15 +78,6 @@
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
             "repeat-element": "^1.1.2"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
           }
         },
         "expand-brackets": {
@@ -154,12 +146,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/types": "7.0.0-beta.53",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.5",
         "source-map": "^0.5.0",
@@ -167,214 +159,214 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.49.tgz",
-      "integrity": "sha1-fZAF1U/nrWy4dnkCUedVdUGRhuk=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.53.tgz",
+      "integrity": "sha1-WZYGKDdcvu+WoH7f4co4t1bwGqg=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.49.tgz",
-      "integrity": "sha1-xi3VBCtUpZDV5x5gIMRrkdbGyHU=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.53.tgz",
+      "integrity": "sha1-RFZwliPX2vqivulPglUD9MDs6Fs=",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.49.tgz",
-      "integrity": "sha1-S11BeCpoPV3GSXg0oyMQqNAqOvk=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.53.tgz",
+      "integrity": "sha1-ld6Lq9A/nmz08rVkoDhwjBOP/jE=",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-hoist-variables": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.49.tgz",
-      "integrity": "sha1-TqBnqnIJNyQN85XNBzwk/K2cKzs=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.53.tgz",
+      "integrity": "sha1-SOniJlRTeHl1BD76qx7a0jnqlpU=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
         "lodash": "^4.17.5"
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.49.tgz",
-      "integrity": "sha1-K/uV337BMHNb9lXkSiF6cNOxPpM=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.53.tgz",
+      "integrity": "sha1-1bytK2tH9ATAruillk3/2TEkc6g=",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
-      "integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+      "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-get-function-arity": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
-      "integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+      "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.49.tgz",
-      "integrity": "sha1-2XQGUck7tPp5wba6xjQFH8TQP/U=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.53.tgz",
+      "integrity": "sha1-TCfjuHP6CcWtbpPrQHBMIA+EE3w=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.49.tgz",
-      "integrity": "sha1-L2QrAD1FFV4KnnpK0OaI2Ru8FYM=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.53.tgz",
+      "integrity": "sha1-D7Dviy07kD0cO/Qm2kp0V14BnOQ=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.49.tgz",
-      "integrity": "sha1-QdfVmJEBbEk0MqRvdGREZVKJDHU=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.53.tgz",
+      "integrity": "sha1-5zXmqjClBLD52Fw4ptRwqfSqgdk=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/types": "7.0.0-beta.53",
         "lodash": "^4.17.5"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.49.tgz",
-      "integrity": "sha1-/GYL2p1kl0EuGHdqca7ZqeLl960=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.53.tgz",
+      "integrity": "sha1-e6IUzcyPhiPy0Xl96v8f80mqzhM=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.49",
-        "@babel/helper-simple-access": "7.0.0-beta.49",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/helper-module-imports": "7.0.0-beta.53",
+        "@babel/helper-simple-access": "7.0.0-beta.53",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
         "lodash": "^4.17.5"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.49.tgz",
-      "integrity": "sha1-qYtDw6bFS+9I+HsQ3EVo3sC0G/c=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.53.tgz",
+      "integrity": "sha1-j8eO9MD2n4uzu980zSMsIBIEFMg=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.49.tgz",
-      "integrity": "sha1-Dp/LuDT4eLs2XSqOqQ7uIbo8zSM=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.53.tgz",
+      "integrity": "sha1-1kRYY2/8JYtCcUqd2Trrb4uM8+0=",
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.49.tgz",
-      "integrity": "sha1-/yRPGcKi8Wf/SzFlpjawj9ZBgWs=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-bp0hl7Vid54iVWWUaumoXCFbIl4=",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-s/2qtBJ4TX6GV7rKsoaSPvyUmLg=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-uDSnVy3sF2OJ/6x+djV5WGSQySI=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.49",
-        "@babel/helper-wrap-function": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+        "@babel/helper-wrap-function": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.49.tgz",
-      "integrity": "sha1-50RMcYBX9qCjZFyvjnj7VG/7DZ8=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.53.tgz",
+      "integrity": "sha1-M5tb3BAilElbGifFWBMjBuG3vKc=",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.0.0-beta.49",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.53",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.49.tgz",
-      "integrity": "sha1-l6QeJ4mpv4psMFNqJYt550RMXYI=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.53.tgz",
+      "integrity": "sha1-cvbbmr5C+GgfpvAo79WdgVRHUrM=",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
         "lodash": "^4.17.5"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
-      "integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+      "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.49.tgz",
-      "integrity": "sha1-OFWRRgtNk++W7jgZU5wM3Ju9R1g=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.53.tgz",
+      "integrity": "sha1-q/sr+pQBBCurJXwBkPWtbbjfFdU=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/helpers": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.49.tgz",
-      "integrity": "sha1-BU2EAy1OlChqgFhlAAaOQQBaUdA=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.53.tgz",
+      "integrity": "sha1-xDb/uOCTAU2olba7d5f/RuPRzM8=",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+      "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -383,441 +375,431 @@
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+      "integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.49.tgz",
-      "integrity": "sha1-h2Gl4ti1JR5w3yj00KpkqiillrE=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.53.tgz",
+      "integrity": "sha1-XFnvZm0Xwn3LVoa3XsMr622MUNY=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.49",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.53",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.49.tgz",
-      "integrity": "sha1-bQzWD3p718REo3HE6UcL/wL1d3w=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.53.tgz",
+      "integrity": "sha1-5rXwusUBg48W6PPG00sAs+pANdk=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.49.tgz",
-      "integrity": "sha1-H1PTZ4UQHV60tV1laGqis5+iHEs=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.53.tgz",
+      "integrity": "sha1-i6DVywtncv66DwxY5u1+oj/S8gI=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.49.tgz",
-      "integrity": "sha1-DvX7mr2pgM0Vhe9Mjo9oC2MmPHI=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-YAlUHdmG6OsKkKJRFSMAEQLn3EM=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-regex": "7.0.0-beta.49",
-        "regexpu-core": "^4.1.4"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-regex": "7.0.0-beta.53",
+        "regexpu-core": "^4.2.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.49.tgz",
-      "integrity": "sha1-UO6UMAKu3JqzqNEikr013Z7bHfg=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.53.tgz",
+      "integrity": "sha1-gpvvbxUBeentC7lDM58qMSM6qSE=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.49.tgz",
-      "integrity": "sha1-R4SziAgj/xLnQsJrQemFf3AdY54=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.53.tgz",
+      "integrity": "sha1-nb12jD8QnwKyT7oXNllp+iXrRYw=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.49.tgz",
-      "integrity": "sha1-Ph3T1drrQnDk7khjZB1Pqga7zRE=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.53.tgz",
+      "integrity": "sha1-pc9szGqrNp/CyleuH0pjs9w4Jes=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.49.tgz",
-      "integrity": "sha1-3ThFtjxoPRh9UYbuDogsQEbE8OM=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.53.tgz",
+      "integrity": "sha1-p19fqEl6rBcp0DO/QcJQQWudHgQ=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-kRpA65MEAYbOtpMQXKdt73/pfQM=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-REx2HMQhXJeptVb/WMp7p99dQVM=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.49"
+        "@babel/helper-module-imports": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.49.tgz",
-      "integrity": "sha1-eqn0b9+HO3IRqqLrDTfEw3Ghq9I=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.53.tgz",
+      "integrity": "sha1-CkMiGhsMkM1NCfG0a5Wd0khlf3M=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.49.tgz",
-      "integrity": "sha1-3Vqd3ZhndciyDPW2EGWvs92eqsk=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.53.tgz",
+      "integrity": "sha1-nv1uUMofo5jcqnEZYh2j8fu4IbY=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
         "lodash": "^4.17.5"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.49.tgz",
-      "integrity": "sha1-U0JHHS5qMzczLqJGtGwL3fX8VE0=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.53.tgz",
+      "integrity": "sha1-XcLsMb8emAZqzfDEiHt3RMFL7G4=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.49",
-        "@babel/helper-define-map": "7.0.0-beta.49",
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-replace-supers": "7.0.0-beta.49",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+        "@babel/helper-define-map": "7.0.0-beta.53",
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-replace-supers": "7.0.0-beta.53",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.49.tgz",
-      "integrity": "sha1-uCWdF0vwerS1ZWZWK0buZSDD39I=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.53.tgz",
+      "integrity": "sha1-l0fiYIKulO2lMPmNLCBZ6NLbwAU=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.49.tgz",
-      "integrity": "sha1-Q2Y5LJyC0SMQVsHQApQ4pg02K4I=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.53.tgz",
+      "integrity": "sha1-DwrbDhptzTWjZkEBYJ7AYv8SenY=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.49.tgz",
-      "integrity": "sha1-Na4rwYe+51LQ93hdJwTlK4c3c2k=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-TEZHMaRf8Fm36TOsdswFzHBlGkA=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-regex": "7.0.0-beta.49",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-regex": "7.0.0-beta.53",
         "regexpu-core": "^4.1.3"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.49.tgz",
-      "integrity": "sha1-+sJEgJ3ey/CV43VVjMtxbaEEIxY=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.53.tgz",
+      "integrity": "sha1-D1WZE6v6GCOcpOCPc+7DbF5XuB8=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-RXstCQBHlGhKpuGwQBUIC4CgihQ=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-PiZxeSBMd1GdhBepsZnyUiIejZU=",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.49.tgz",
-      "integrity": "sha1-PscnJr8diaDU1RG+epVJBm9Xqt4=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.53.tgz",
+      "integrity": "sha1-+gZSFeGFacj3TdUktXIeEdzKlzs=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.49.tgz",
-      "integrity": "sha1-rzn2Dnrvzpsl60rc7dBNUIZs4hg=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.53.tgz",
+      "integrity": "sha1-Kzpbs2TB4cV+zL/iXGv1XygEET4=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.49.tgz",
-      "integrity": "sha1-B8g4JU1l5oZ+hlE+sPItXyawpWo=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.53.tgz",
+      "integrity": "sha1-vsTxROmpbvUSHRQwx+vl/QiGV8k=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.49.tgz",
-      "integrity": "sha1-FtB0gJVLBBXqcPHsPtvQWXvT3f4=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.53.tgz",
+      "integrity": "sha1-WFTXOeZ5IzqId8C0GCaca+t6Miw=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-module-transforms": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.49.tgz",
-      "integrity": "sha1-Cfs0XVknwro72J582xOlUGftOaA=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.53.tgz",
+      "integrity": "sha1-68P7ocWmyHQ7kJQD7NPn42gcr6U=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-simple-access": "7.0.0-beta.49"
+        "@babel/helper-module-transforms": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-simple-access": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.49.tgz",
-      "integrity": "sha1-aCJaOuExJ3G8Wjb3H/ENAsEkPZ8=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.53.tgz",
+      "integrity": "sha1-uA/NnBWXLcaCMhT1JIUnhgu/BY4=",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-hoist-variables": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.49.tgz",
-      "integrity": "sha1-cEjKWncYlwb0s+luS5luswWQ3WM=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.53.tgz",
+      "integrity": "sha1-Kjar5AodpnbkOhwwcVeOJ70tZ50=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-module-transforms": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.49.tgz",
-      "integrity": "sha1-wv/vHruvckqeWN3hFOV+Pmhkpec=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.53.tgz",
+      "integrity": "sha1-m3Sz1TtOhUzw42DwLCpEAwccagE=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.49.tgz",
-      "integrity": "sha1-swL1VwKEc0PBD/T7hDXMNXR1X+M=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.53.tgz",
+      "integrity": "sha1-4sTwbts0s9eksnV7oYgp0N8gKcs=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-replace-supers": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-replace-supers": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.49.tgz",
-      "integrity": "sha1-HK1xoqMygeXvuxpGI6lkwHPOmi0=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.53.tgz",
+      "integrity": "sha1-7+YM7IzsoNGdXG+hrnm8TjMnnVY=",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "7.0.0-beta.49",
-        "@babel/helper-get-function-arity": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-call-delegate": "7.0.0-beta.53",
+        "@babel/helper-get-function-arity": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-1O15ZwM/T1tJNjwgNQOJm4NXyuI=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-T+u/YISvoMHJ7ISX3mjAaV/p2gs=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.12.3"
+        "regenerator-transform": "^0.13.3"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.49.tgz",
-      "integrity": "sha1-SfE0295PZVg0whUk6eYaWNTheQA=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.53.tgz",
+      "integrity": "sha1-38SIG2vXZYoAMew7gWPliPCJjUs=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.49.tgz",
-      "integrity": "sha1-arqwX8DMqCmq+eKoUES3l2Pmgco=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.53.tgz",
+      "integrity": "sha1-g+j2Rsok8cmCKPnxREz2DL1JOLw=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.49.tgz",
-      "integrity": "sha1-CMxbZM9qWUKoe92bSkgY1MuhLfM=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-D888mUq92Lq1m6l4L+TZ+KVF1uc=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-regex": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-regex": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.49.tgz",
-      "integrity": "sha1-5gmu1rj8x+HrzKzyITimRyApQKI=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.53.tgz",
+      "integrity": "sha1-+msLQXEA0j4tsUwd9HorGzl48dk=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.49.tgz",
-      "integrity": "sha1-NlFBujVb9znu/Wwrud8cO3FG5FA=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.53.tgz",
+      "integrity": "sha1-ZarocamqQPYRSDZlcxIJrr1cKis=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.49.tgz",
-      "integrity": "sha1-w3XbVwl1diFSPUGstiqavw1DdLg=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-CvdOyAGefVnji+ZNt/YikZQv7SU=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-regex": "7.0.0-beta.49",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-regex": "7.0.0-beta.53",
         "regexpu-core": "^4.1.3"
       }
     },
     "@babel/preset-env": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.49.tgz",
-      "integrity": "sha1-SoqLkhOfUfovkPv28frXWXUyrrw=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.53.tgz",
+      "integrity": "sha1-KyBL9CZ14WbdpaJ1bEHrvyKbs34=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.49",
-        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.49",
-        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.49",
-        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.49",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.49",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.49",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.49",
-        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.49",
-        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.49",
-        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.49",
-        "@babel/plugin-transform-block-scoping": "7.0.0-beta.49",
-        "@babel/plugin-transform-classes": "7.0.0-beta.49",
-        "@babel/plugin-transform-computed-properties": "7.0.0-beta.49",
-        "@babel/plugin-transform-destructuring": "7.0.0-beta.49",
-        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.49",
-        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.49",
-        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.49",
-        "@babel/plugin-transform-for-of": "7.0.0-beta.49",
-        "@babel/plugin-transform-function-name": "7.0.0-beta.49",
-        "@babel/plugin-transform-literals": "7.0.0-beta.49",
-        "@babel/plugin-transform-modules-amd": "7.0.0-beta.49",
-        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.49",
-        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.49",
-        "@babel/plugin-transform-modules-umd": "7.0.0-beta.49",
-        "@babel/plugin-transform-new-target": "7.0.0-beta.49",
-        "@babel/plugin-transform-object-super": "7.0.0-beta.49",
-        "@babel/plugin-transform-parameters": "7.0.0-beta.49",
-        "@babel/plugin-transform-regenerator": "7.0.0-beta.49",
-        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.49",
-        "@babel/plugin-transform-spread": "7.0.0-beta.49",
-        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.49",
-        "@babel/plugin-transform-template-literals": "7.0.0-beta.49",
-        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.49",
-        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.49",
+        "@babel/helper-module-imports": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.53",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.53",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.53",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.53",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.53",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.53",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.53",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.53",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.53",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.53",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.53",
+        "@babel/plugin-transform-classes": "7.0.0-beta.53",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.53",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.53",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.53",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.53",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.53",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.53",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.53",
+        "@babel/plugin-transform-literals": "7.0.0-beta.53",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.53",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.53",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.53",
+        "@babel/plugin-transform-modules-umd": "7.0.0-beta.53",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.53",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.53",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.53",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.53",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.53",
+        "@babel/plugin-transform-spread": "7.0.0-beta.53",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.53",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.53",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.53",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.53",
         "browserslist": "^3.0.0",
         "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
         "semver": "^5.3.0"
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
-      "integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+      "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/code-frame": "7.0.0-beta.53",
+        "@babel/parser": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
         "lodash": "^4.17.5"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
-      "integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+      "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/code-frame": "7.0.0-beta.53",
+        "@babel/generator": "7.0.0-beta.53",
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+        "@babel/parser": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
         "invariant": "^2.2.0",
         "lodash": "^4.17.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
-      "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+      "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -832,9 +814,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.0.tgz",
-      "integrity": "sha512-QatFQ4C0n+PLqemyC6zXEv04tSqRR0hRqe+uGKPEVgKe2G8kl8wJvHzRYWwz6vqqEqt6idPVMFojZ4P1zlyAzQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-globals": {
@@ -918,12 +900,12 @@
       }
     },
     "append-transform": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^1.0.0"
+        "default-require-extensions": "^2.0.0"
       }
     },
     "argparse": {
@@ -1147,13 +1129,13 @@
       }
     },
     "babel-jest": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.0.1.tgz",
-      "integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.4.0.tgz",
+      "integrity": "sha1-IsNMOS4hdvakw2eZKn/P9p0uhVc=",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "^4.1.6",
-        "babel-preset-jest": "^23.0.1"
+        "babel-preset-jest": "^23.2.0"
       }
     },
     "babel-messages": {
@@ -1178,9 +1160,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz",
-      "integrity": "sha1-6qEclkVjrqnCG+zvK994U/fzwUg=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+      "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -1189,30 +1171,13 @@
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
-      }
-    },
     "babel-preset-jest": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz",
-      "integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+      "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^23.0.1",
+        "babel-plugin-jest-hoist": "^23.2.0",
         "babel-plugin-syntax-object-rest-spread": "^6.13.0"
       }
     },
@@ -1257,6 +1222,15 @@
             "slash": "^1.0.0",
             "source-map": "^0.5.7"
           }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -1264,6 +1238,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1299,6 +1274,15 @@
         "lodash": "^4.17.4"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -1395,9 +1379,9 @@
       }
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1457,9 +1441,9 @@
       "dev": true
     },
     "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
       "dev": true,
       "requires": {
         "resolve": "1.1.7"
@@ -1535,9 +1519,9 @@
       "optional": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000847",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000847.tgz",
-      "integrity": "sha512-Weo+tRtVWcN2da782Ebx/27hFNEb+KP+uP6tdqAa+2S5bp1zOJhVH9tEpDygagrfvU4QjeuPwi/5VGsgT4SLaA==",
+      "version": "1.0.30000865",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
+      "integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw==",
       "dev": true
     },
     "capture-exit": {
@@ -1578,24 +1562,25 @@
       }
     },
     "chokidar": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-      "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
       "optional": true,
       "requires": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.0",
         "braces": "^2.3.0",
-        "fsevents": "^1.1.2",
+        "fsevents": "^1.2.2",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
         "normalize-path": "^2.1.1",
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.0.0",
-        "upath": "^1.0.0"
+        "upath": "^1.0.5"
       }
     },
     "ci-info": {
@@ -1671,18 +1656,18 @@
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
     },
     "combined-stream": {
@@ -1695,15 +1680,15 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
       "dev": true
     },
     "compare-versions": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.2.1.tgz",
-      "integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
+      "integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==",
       "dev": true
     },
     "component-emitter": {
@@ -1733,7 +1718,8 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1753,9 +1739,9 @@
       }
     },
     "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
       "dev": true
     },
     "cssstyle": {
@@ -1788,10 +1774,9 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1815,12 +1800,20 @@
       "dev": true
     },
     "default-require-extensions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "^2.0.0"
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "define-properties": {
@@ -1927,15 +1920,15 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.48",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
-      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA=",
+      "version": "1.3.52",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
+      "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
       "dev": true
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -1972,9 +1965,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+      "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -2006,9 +1999,9 @@
       "dev": true
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "estraverse": {
@@ -2039,12 +2032,12 @@
       }
     },
     "exec-sh": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "dev": true,
       "requires": {
-        "merge": "^1.1.3"
+        "merge": "^1.2.0"
       }
     },
     "execa": {
@@ -2083,6 +2076,15 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -2155,17 +2157,17 @@
       }
     },
     "expect": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
-      "integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-23.4.0.tgz",
+      "integrity": "sha1-baTsyZwUcSU+cogziYOtHrrbYMM=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
-        "jest-diff": "^23.0.1",
+        "jest-diff": "^23.2.0",
         "jest-get-type": "^22.1.0",
-        "jest-matcher-utils": "^23.0.1",
-        "jest-message-util": "^23.1.0",
-        "jest-regex-util": "^23.0.0"
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.4.0",
+        "jest-regex-util": "^23.3.0"
       }
     },
     "extend": {
@@ -2342,21 +2344,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
       "requires": {
         "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "for-in": {
@@ -2960,9 +2952,9 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
     "get-stream": {
@@ -3060,9 +3052,9 @@
       }
     },
     "globals": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-      "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
       "dev": true
     },
     "graceful-fs": {
@@ -3123,12 +3115,12 @@
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -3189,9 +3181,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -3318,9 +3310,9 @@
       }
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-ci": {
@@ -3455,23 +3447,6 @@
         }
       }
     },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
-    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -3589,12 +3564,12 @@
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
-      "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
+      "integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0"
+        "append-transform": "^1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -3652,17 +3627,6 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.6.1",
         "source-map": "^0.5.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "istanbul-reports": {
@@ -3675,13 +3639,13 @@
       }
     },
     "jest": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-23.1.0.tgz",
-      "integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-23.4.0.tgz",
+      "integrity": "sha1-685j9lKcJ8ZG2AxhCGbwMG9m3L8=",
       "dev": true,
       "requires": {
         "import-local": "^1.0.0",
-        "jest-cli": "^23.1.0"
+        "jest-cli": "^23.4.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3750,9 +3714,9 @@
           }
         },
         "jest-cli": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.1.0.tgz",
-          "integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
+          "version": "23.4.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.4.0.tgz",
+          "integrity": "sha1-0f3R28Qdaa6L1D0AcM4jmI6s2G8=",
           "dev": true,
           "requires": {
             "ansi-escapes": "^3.0.0",
@@ -3766,23 +3730,24 @@
             "istanbul-lib-coverage": "^1.2.0",
             "istanbul-lib-instrument": "^1.10.1",
             "istanbul-lib-source-maps": "^1.2.4",
-            "jest-changed-files": "^23.0.1",
-            "jest-config": "^23.1.0",
-            "jest-environment-jsdom": "^23.1.0",
+            "jest-changed-files": "^23.4.0",
+            "jest-config": "^23.4.0",
+            "jest-environment-jsdom": "^23.4.0",
             "jest-get-type": "^22.1.0",
-            "jest-haste-map": "^23.1.0",
-            "jest-message-util": "^23.1.0",
-            "jest-regex-util": "^23.0.0",
-            "jest-resolve-dependencies": "^23.0.1",
-            "jest-runner": "^23.1.0",
-            "jest-runtime": "^23.1.0",
-            "jest-snapshot": "^23.0.1",
-            "jest-util": "^23.1.0",
-            "jest-validate": "^23.0.1",
-            "jest-watcher": "^23.1.0",
-            "jest-worker": "^23.0.1",
+            "jest-haste-map": "^23.4.0",
+            "jest-message-util": "^23.4.0",
+            "jest-regex-util": "^23.3.0",
+            "jest-resolve-dependencies": "^23.4.0",
+            "jest-runner": "^23.4.0",
+            "jest-runtime": "^23.4.0",
+            "jest-snapshot": "^23.4.0",
+            "jest-util": "^23.4.0",
+            "jest-validate": "^23.4.0",
+            "jest-watcher": "^23.4.0",
+            "jest-worker": "^23.2.0",
             "micromatch": "^2.3.11",
             "node-notifier": "^5.2.1",
+            "prompts": "^0.1.9",
             "realpath-native": "^1.0.0",
             "rimraf": "^2.5.4",
             "slash": "^1.0.0",
@@ -3834,33 +3799,33 @@
       }
     },
     "jest-changed-files": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.0.1.tgz",
-      "integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.0.tgz",
+      "integrity": "sha1-8bME+YwjWvXZox7FJCYsXk3jxv8=",
       "dev": true,
       "requires": {
         "throat": "^4.0.0"
       }
     },
     "jest-config": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
-      "integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.0.tgz",
+      "integrity": "sha1-ecz41oqg5I+eO+uBuDqlh1xj+j8=",
       "dev": true,
       "requires": {
         "babel-core": "^6.0.0",
-        "babel-jest": "^23.0.1",
+        "babel-jest": "^23.4.0",
         "chalk": "^2.0.1",
         "glob": "^7.1.1",
-        "jest-environment-jsdom": "^23.1.0",
-        "jest-environment-node": "^23.1.0",
+        "jest-environment-jsdom": "^23.4.0",
+        "jest-environment-node": "^23.4.0",
         "jest-get-type": "^22.1.0",
-        "jest-jasmine2": "^23.1.0",
-        "jest-regex-util": "^23.0.0",
-        "jest-resolve": "^23.1.0",
-        "jest-util": "^23.1.0",
-        "jest-validate": "^23.0.1",
-        "pretty-format": "^23.0.1"
+        "jest-jasmine2": "^23.4.0",
+        "jest-regex-util": "^23.3.0",
+        "jest-resolve": "^23.4.0",
+        "jest-util": "^23.4.0",
+        "jest-validate": "^23.4.0",
+        "pretty-format": "^23.2.0"
       },
       "dependencies": {
         "babel-core": {
@@ -3889,59 +3854,68 @@
             "slash": "^1.0.0",
             "source-map": "^0.5.7"
           }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
     "jest-diff": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
-      "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
+      "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "diff": "^3.2.0",
         "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.0.1"
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-docblock": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.0.1.tgz",
-      "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
+      "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
       "dev": true,
       "requires": {
         "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.1.0.tgz",
-      "integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.4.0.tgz",
+      "integrity": "sha1-L6nt2J2qGk7cn/m/YGKja3E0UUM=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
-        "pretty-format": "^23.0.1"
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
-      "integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
+      "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
       "dev": true,
       "requires": {
-        "jest-mock": "^23.1.0",
-        "jest-util": "^23.1.0",
+        "jest-mock": "^23.2.0",
+        "jest-util": "^23.4.0",
         "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
-      "integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
+      "integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
       "dev": true,
       "requires": {
-        "jest-mock": "^23.1.0",
-        "jest-util": "^23.1.0"
+        "jest-mock": "^23.2.0",
+        "jest-util": "^23.4.0"
       }
     },
     "jest-get-type": {
@@ -3951,16 +3925,16 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.1.0.tgz",
-      "integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.4.0.tgz",
+      "integrity": "sha1-8qDqpBr3Zs1RAebCkf3GQ1yT7hw=",
       "dev": true,
       "requires": {
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.1.11",
-        "jest-docblock": "^23.0.1",
+        "jest-docblock": "^23.2.0",
         "jest-serializer": "^23.0.1",
-        "jest-worker": "^23.0.1",
+        "jest-worker": "^23.2.0",
         "micromatch": "^2.3.11",
         "sane": "^2.0.0"
       },
@@ -4057,48 +4031,48 @@
       }
     },
     "jest-jasmine2": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
-      "integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.0.tgz",
+      "integrity": "sha1-F85Tn+YI74mNaYZRgUSs8nC+yo8=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "co": "^4.6.0",
-        "expect": "^23.1.0",
+        "expect": "^23.4.0",
         "is-generator-fn": "^1.0.0",
-        "jest-diff": "^23.0.1",
-        "jest-each": "^23.1.0",
-        "jest-matcher-utils": "^23.0.1",
-        "jest-message-util": "^23.1.0",
-        "jest-snapshot": "^23.0.1",
-        "jest-util": "^23.1.0",
-        "pretty-format": "^23.0.1"
+        "jest-diff": "^23.2.0",
+        "jest-each": "^23.4.0",
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.4.0",
+        "jest-snapshot": "^23.4.0",
+        "jest-util": "^23.4.0",
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-leak-detector": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz",
-      "integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz",
+      "integrity": "sha1-wonZYdxjjxQ1fU75bgQx7MGqN30=",
       "dev": true,
       "requires": {
-        "pretty-format": "^23.0.1"
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
-      "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
+      "integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.0.1"
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-message-util": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
-      "integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
+      "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0-beta.35",
@@ -4200,55 +4174,55 @@
       }
     },
     "jest-mock": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
-      "integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
+      "integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
       "dev": true
     },
     "jest-regex-util": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-      "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
+      "integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U=",
       "dev": true
     },
     "jest-resolve": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
-      "integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.0.tgz",
+      "integrity": "sha1-tAYdvNY5G15EXV/YTJ2tX/H/VmI=",
       "dev": true,
       "requires": {
-        "browser-resolve": "^1.11.2",
+        "browser-resolve": "^1.11.3",
         "chalk": "^2.0.1",
         "realpath-native": "^1.0.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz",
-      "integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.0.tgz",
+      "integrity": "sha1-5z785wJipuK/UmPQsjAJoJhnhiA=",
       "dev": true,
       "requires": {
-        "jest-regex-util": "^23.0.0",
-        "jest-snapshot": "^23.0.1"
+        "jest-regex-util": "^23.3.0",
+        "jest-snapshot": "^23.4.0"
       }
     },
     "jest-runner": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.1.0.tgz",
-      "integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.4.0.tgz",
+      "integrity": "sha1-GFmyEaJk6lpDt6MCLhGZBnxN/lc=",
       "dev": true,
       "requires": {
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.11",
-        "jest-config": "^23.1.0",
-        "jest-docblock": "^23.0.1",
-        "jest-haste-map": "^23.1.0",
-        "jest-jasmine2": "^23.1.0",
-        "jest-leak-detector": "^23.0.1",
-        "jest-message-util": "^23.1.0",
-        "jest-runtime": "^23.1.0",
-        "jest-util": "^23.1.0",
-        "jest-worker": "^23.0.1",
+        "jest-config": "^23.4.0",
+        "jest-docblock": "^23.2.0",
+        "jest-haste-map": "^23.4.0",
+        "jest-jasmine2": "^23.4.0",
+        "jest-leak-detector": "^23.2.0",
+        "jest-message-util": "^23.4.0",
+        "jest-runtime": "^23.4.0",
+        "jest-util": "^23.4.0",
+        "jest-worker": "^23.2.0",
         "source-map-support": "^0.5.6",
         "throat": "^4.0.0"
       },
@@ -4272,9 +4246,9 @@
       }
     },
     "jest-runtime": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.1.0.tgz",
-      "integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.4.0.tgz",
+      "integrity": "sha1-ww72Gd71h7k7rUpJONqazLmTa00=",
       "dev": true,
       "requires": {
         "babel-core": "^6.0.0",
@@ -4284,14 +4258,14 @@
         "exit": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.1.11",
-        "jest-config": "^23.1.0",
-        "jest-haste-map": "^23.1.0",
-        "jest-message-util": "^23.1.0",
-        "jest-regex-util": "^23.0.0",
-        "jest-resolve": "^23.1.0",
-        "jest-snapshot": "^23.0.1",
-        "jest-util": "^23.1.0",
-        "jest-validate": "^23.0.1",
+        "jest-config": "^23.4.0",
+        "jest-haste-map": "^23.4.0",
+        "jest-message-util": "^23.4.0",
+        "jest-regex-util": "^23.3.0",
+        "jest-resolve": "^23.4.0",
+        "jest-snapshot": "^23.4.0",
+        "jest-util": "^23.4.0",
+        "jest-validate": "^23.4.0",
         "micromatch": "^2.3.11",
         "realpath-native": "^1.0.0",
         "slash": "^1.0.0",
@@ -4351,6 +4325,15 @@
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
             "repeat-element": "^1.1.2"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "expand-brackets": {
@@ -4431,30 +4414,35 @@
       "dev": true
     },
     "jest-snapshot": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
-      "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.0.tgz",
+      "integrity": "sha1-dGPQNXyr3+HGOZTV4y9wfRAz1hY=",
       "dev": true,
       "requires": {
+        "babel-traverse": "^6.0.0",
+        "babel-types": "^6.0.0",
         "chalk": "^2.0.1",
-        "jest-diff": "^23.0.1",
-        "jest-matcher-utils": "^23.0.1",
+        "jest-diff": "^23.2.0",
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.4.0",
+        "jest-resolve": "^23.4.0",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^23.0.1"
+        "pretty-format": "^23.2.0",
+        "semver": "^5.5.0"
       }
     },
     "jest-util": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
-      "integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
+      "integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
       "dev": true,
       "requires": {
         "callsites": "^2.0.0",
         "chalk": "^2.0.1",
         "graceful-fs": "^4.1.11",
         "is-ci": "^1.0.10",
-        "jest-message-util": "^23.1.0",
+        "jest-message-util": "^23.4.0",
         "mkdirp": "^0.5.1",
         "slash": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4469,21 +4457,21 @@
       }
     },
     "jest-validate": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
-      "integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
+      "integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "jest-get-type": "^22.1.0",
         "leven": "^2.1.0",
-        "pretty-format": "^23.0.1"
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-watcher": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.1.0.tgz",
-      "integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
+      "integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -4492,13 +4480,19 @@
       }
     },
     "jest-worker": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.1.tgz",
-      "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+      "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
       "dev": true,
       "requires": {
         "merge-stream": "^1.0.1"
       }
+    },
+    "js-levenshtein": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.3.tgz",
+      "integrity": "sha512-/812MXr9RBtMObviZ8gQBhHO8MOrGj8HlEE+4ccMTElNA/6I3u39u+bhny55Lk921yn44nSZFy9naNLElL5wgQ==",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -4507,9 +4501,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -4622,6 +4616,12 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
+    "kleur": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-1.0.1.tgz",
+      "integrity": "sha512-8srIZ5BK5PCJw1L/JN741xgNfSjuQNK9ImYbYzv7ZUD3WPfuywaY+yd7lQOphJ+2vwXnMLnRZoAh5X+orRt4LQ==",
+      "dev": true
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -4689,6 +4689,13 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true,
+      "optional": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -4702,12 +4709,12 @@
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lru-cache": {
@@ -4886,9 +4893,9 @@
       "optional": true
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -4896,7 +4903,6 @@
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
         "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
         "is-windows": "^1.0.2",
         "kind-of": "^6.0.2",
         "object.pick": "^1.3.0",
@@ -5058,9 +5064,9 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.1.tgz",
-      "integrity": "sha512-xOJJb7kAAGy6UOklbaIPA0iu/27VMHfAbMUgYJlXz4qRXytIkPGM2vwfbxa+tbaqcqHNsP6RN4eDZlePelWKpQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.4.tgz",
+      "integrity": "sha512-Zt6HRR6RcJkuj5/N9zeE7FN6YitRW//hK2wTOwX274IBphbY3Zf5+yn5mZ9v/SzAOTMjQNxZf9KkmPLWn0cV4g==",
       "dev": true
     },
     "oauth-sign": {
@@ -5107,9 +5113,9 @@
       }
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
     "object-visit": {
@@ -5232,9 +5238,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
         "p-try": "^1.0.0"
@@ -5417,9 +5423,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-      "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+      "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
       "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0",
@@ -5446,6 +5452,16 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
+    "prompts": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.12.tgz",
+      "integrity": "sha512-pgR1GE1JM8q8UsHVIgjdK62DPwvrf0kvaKWJ/mfMoCm2lwfIReX/giQ1p0AlMoUXNhQap/8UiOdqi3bOROm/eg==",
+      "dev": true,
+      "requires": {
+        "kleur": "^1.0.0",
+        "sisteransi": "^0.1.1"
+      }
+    },
     "ps-tree": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
@@ -5459,6 +5475,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
+      "integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==",
       "dev": true
     },
     "punycode": {
@@ -5563,9 +5585,9 @@
       }
     },
     "realpath-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
-      "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.1.tgz",
+      "integrity": "sha512-W14EcXuqUvKP8dkWkD7B95iMy77lpMnlFXbbk409bQtNCbeu0kvRE5reo+yIZ3JXxg6frbGsz2DLQ39lrCB40g==",
       "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
@@ -5578,23 +5600,24 @@
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-6.0.0.tgz",
-      "integrity": "sha512-BvXxRS7RfVWxtm7vrq+0I0j7sqZ1zeSC+yzf5HS0qLnKcZPX541gFEGB39LvGuKHrkyKXrzXug+oC7xkM1Zovw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.3.3"
+        "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
-      "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+      "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
       "dev": true,
       "requires": {
         "private": "^0.1.6"
@@ -5620,17 +5643,17 @@
       }
     },
     "regexpu-core": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.5.tgz",
-      "integrity": "sha512-3xo5pFze1F8oR4F9x3aFbdtdxAxQ9WBX6gXfLgeBt7KpDI0+oDF7WVntnhsPKqobU/GAYc2pmx+y3z0JI1+z3w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+      "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^6.0.0",
+        "regenerate-unicode-properties": "^7.0.0",
         "regjsgen": "^0.4.0",
         "regjsparser": "^0.3.0",
-        "unicode-match-property-ecmascript": "^1.0.3",
-        "unicode-match-property-value-ecmascript": "^1.0.1"
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.0.2"
       }
     },
     "regjsgen": {
@@ -5709,6 +5732,23 @@
         "tough-cookie": "~2.3.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "request-promise-core": {
@@ -5744,9 +5784,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
@@ -5818,6 +5858,12 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "2.5.2",
@@ -5931,6 +5977,12 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sisteransi": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
+      "integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==",
+      "dev": true
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -5953,6 +6005,15 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -6135,9 +6196,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -6147,6 +6208,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
@@ -6385,11 +6447,12 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
+        "psl": "^1.1.24",
         "punycode": "^1.4.1"
       },
       "dependencies": {
@@ -6476,31 +6539,31 @@
       "optional": true
     },
     "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
-      "integrity": "sha512-iG/2t0F2LAU8aZYPkX5gi7ebukHnr3sWFESpb+zPQeeaQwOkfoO6ZW17YX7MdRPNG9pCy+tjzGill+Ah0Em0HA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
       "dev": true
     },
     "unicode-match-property-ecmascript": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
-      "integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.2",
-        "unicode-property-aliases-ecmascript": "^1.0.3"
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.1.tgz",
-      "integrity": "sha512-lM8B0FDZQh9yYGgiabRQcyWicB27VLOolSBRIxsO7FeQPtg+79Oe7sC8Mzr8BObDs+G9CeYmC/shHo6OggNEog==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz",
-      "integrity": "sha512-TdDmDOTxEf2ad1g3ZBpM6cqKIb2nJpVlz1Q++casDryKz18tpeMBhSng9hjC1CTQCkOV9Rw2knlSB6iRo7ad1w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
       "dev": true
     },
     "union-value": {
@@ -6592,13 +6655,10 @@
       "dev": true
     },
     "use": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-      "dev": true,
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -6617,9 +6677,9 @@
       }
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -6701,9 +6761,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
-      "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -6817,9 +6877,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {
         "cliui": "^4.0.0",

--- a/@uportal/open-id-connect/package.json
+++ b/@uportal/open-id-connect/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "babel-polyfill": "^6.26.0",
     "jwt-decode": "^2.2.0"
   },
   "devDependencies": {

--- a/@uportal/open-id-connect/src/open-id-connect.js
+++ b/@uportal/open-id-connect/src/open-id-connect.js
@@ -1,6 +1,5 @@
 import {get} from 'axios';
 import decode from 'jwt-decode';
-import 'babel-polyfill'; // needed to apply async/await polyfills
 
 let token = null;
 


### PR DESCRIPTION
This results in babel-polyfill is already defined warnings and page bloat.
Instead let implementors apply polyfills as wanted/needed.

/cc @jgribonvald @mrapczynski @jonathanmtran