### PR TITLE
fix(content-carousel): vue property decorator type annotations

### DIFF
--- a/@uportal/content-carousel/src/components/ContentCarousel.ts
+++ b/@uportal/content-carousel/src/components/ContentCarousel.ts
@@ -11,9 +11,9 @@ import { PortletStrategy } from '@/lib/PortletStrategy';
     },
 })
 export default class ContentCarousel extends Vue {
-    @Prop() public type!: string;
-    @Prop() public source!: string;
-    @Prop() public slickOptions: any = {};
+    @Prop([String]) public type!: string;
+    @Prop([String]) public source!: string;
+    @Prop() public slickOptions: any;
     @Prop([String]) public carouselHeight?: string;
     @Prop([Boolean]) public fitToContainer?: boolean;
 


### PR DESCRIPTION
default assignment breaks vue property decorator.