### PR TITLE
feat(content-carousel): add passthrough mode

### DIFF
--- a/@uportal/content-carousel/README.md
+++ b/@uportal/content-carousel/README.md
@@ -74,6 +74,24 @@ portletOptions = {
   :type="'portlet'"
   :source="'/portletRegistry.json'"
   :slickOptions="portletOptions" />
+
+<ContentCarousel :type="'passthrough'">
+  <div>
+    arbitrary
+  </div>
+  <div>
+    content
+  </div>
+  <div>
+    displayed
+  </div>
+  <div>
+    as
+  </div>
+  <div>
+    slides
+  </div>
+</ContentCarousel>
 ```
 
 ## Options

--- a/@uportal/content-carousel/src/App.vue
+++ b/@uportal/content-carousel/src/App.vue
@@ -22,6 +22,28 @@
         :slickOptions="portletOptions"
         :carouselHeight="portletHeight" />
     </section>
+    <section class="content">
+      <ContentCarousel
+        :type="'passthrough'"
+        :slickOptions="contentOptions"
+        :carouselHeight="portletHeight">
+        <div>
+          arbitrary
+        </div>
+        <div>
+          content
+        </div>
+        <div>
+          displayed
+        </div>
+        <div>
+          as
+        </div>
+        <div>
+          slides
+        </div>
+      </ContentCarousel>
+    </section>
   </main>
 </template>
 <script lang="ts" src="./App.ts">

--- a/@uportal/content-carousel/src/components/ContentCarousel.html
+++ b/@uportal/content-carousel/src/components/ContentCarousel.html
@@ -8,6 +8,7 @@
         </a>
         <p v-if="!item.imageUrl">{{ item.description }}</p>
       </div>
+      <slot v-if="type === 'passthrough'" />
     </slick>
   </template>
 </div>

--- a/@uportal/content-carousel/src/components/ContentCarousel.ts
+++ b/@uportal/content-carousel/src/components/ContentCarousel.ts
@@ -46,6 +46,12 @@ export default class ContentCarousel extends Vue {
           }
           case 'portlet': {
             this.strategy = new PortletStrategy(this.source);
+            break;
+          }
+          case 'passthrough': {
+            // ensure 'passthrough' is lowercase
+            this.type = this.type.toLowerCase();
+            break;
           }
           default: {
             console.error(`type: "${this.type}" is not recognized`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][]
 
+### Feature
+
+- **content-carousel**: `passthrough` mode which allows arbitrary content to be added as carousel slides (#41).
+
 ## [1.4.0][] - 2018-07-26
 
 ### Feature


### PR DESCRIPTION
passthrough mode allows arbitary content to be turned into a carousel.