### PR TITLE
fix(content-carousel): update slick slide selector to use vue element

### DIFF
--- a/@uportal/content-carousel/src/components/ContentCarousel.ts
+++ b/@uportal/content-carousel/src/components/ContentCarousel.ts
@@ -81,8 +81,10 @@ export default class ContentCarousel extends Vue {
   }
 
   get computedSlickOptions(): Object {
-    return typeof this.slickOptions === 'string'
+    const options = typeof this.slickOptions === 'string'
       ? JSON.parse(this.slickOptions)
       : this.slickOptions;
+
+    return {slick: this.$el, ...options};
   }
 }


### PR DESCRIPTION
Component now renders on Firefox with the Web Component build

![screenshot_2018-08-28 content-carousel demo](https://user-images.githubusercontent.com/3107513/44730148-29076680-aa95-11e8-9218-f084640f8ed3.png)
