### PR TITLE
feat(content-carousel): render description content as html

### DIFF
--- a/@uportal/content-carousel/src/components/ContentCarousel.html
+++ b/@uportal/content-carousel/src/components/ContentCarousel.html
@@ -13,7 +13,7 @@
           <img v-if="item.imageUrl" :src="item.imageUrl" :alt="item.altText">
           <template v-if="!item.imageUrl">{{ item.title }}</template>
         </a>
-        <p v-if="!item.imageUrl">{{ item.description }}</p>
+        <p v-if="!item.imageUrl" v-html="item.description"></p>
       </div>
       <slot v-if="type === 'passthrough'" />
     </slick>


### PR DESCRIPTION
Allows sample RSS provided by @jonathanmtran to render links and styles
![screenshot_2018-08-28 content carousel demo](https://user-images.githubusercontent.com/3107513/44733351-44c23b00-aa9c-11e8-9db1-9979b3d250ab.png)
#67 will improve appearance of complex text slides.