### PR TITLE
fix: implement 'destinationUrl' in the data model for PortletStrategy

### DIFF
--- a/@uportal/content-carousel/src/lib/PortletStrategy.ts
+++ b/@uportal/content-carousel/src/lib/PortletStrategy.ts
@@ -49,7 +49,7 @@ export class PortletStrategy implements DataStrategy {
         return {
           id: fname,
           altText,
-          destinationUrl: 'TODO',
+          destinationUrl: '/uPortal/p/' + fname,
           imageUrl,
           title: name,
           description,


### PR DESCRIPTION
This solution will work for most folks.  There are a very few uPortal implementations that deploy uPortal to the ROOT context of Tomcat (at least there have been).

For future consideration, a better solution would either...

  - Detect the `contextName` (either `/uPortal`, `/`, or something else entirely) based on the current page URI;  or
  - Provide a `contextName` property -- with a default value of `/uPortal` -- that can be overridden in the custom element markup.