### PR TITLE
docs: add Julien as a committer

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -12,6 +12,7 @@ With the addition of the following committers:
 
 - Chris Beach (@cbeach47)
 - Chris Paraiso (@cparaiso)
+- Julien Gribonvald (@gribonvald)
 - Phillip Ball (@illiphilli)
 - Ryan Mathis (@rmathis)
 


### PR DESCRIPTION
Invite sent as collaborator, until one of the steering committee members can invite him to the uportal-contrib organization.