### PR TITLE
fix(esco-content-portlet): setup contextApiUrl inside the content grid

### DIFF
--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -50,6 +50,10 @@ export default {
         process.env.VUE_APP_PORTAL_CONTEXT +
         process.env.VUE_APP_FAVORITES_PORTLETS_URI
     },
+    contextApiUrl: {
+      type: String,
+      default: process.env.VUE_APP_PORTAL_CONTEXT
+    },
     userInfoApiUrl: {
       type: String,
       default:


### PR DESCRIPTION
helper needs this to allow base URL to be customized