### PR TITLE
build: update release process

### DIFF
--- a/@uportal/content-carousel/package.json
+++ b/@uportal/content-carousel/package.json
@@ -7,7 +7,6 @@
   "main": "dist/content-carousel.js",
   "source": "src/components/content-carousel.vue",
   "scripts": {
-    "prepublishOnly": "npm run build",
     "start": "vue-cli-service serve",
     "prebuild": "babel node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js -o node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js",
     "build": "vue-cli-service build --name content-carousel --target wc 'src/components/*.vue'"

--- a/@uportal/esco-content-menu/package.json
+++ b/@uportal/esco-content-menu/package.json
@@ -2,7 +2,6 @@
   "name": "@uportal/esco-content-menu",
   "version": "1.13.2",
   "scripts": {
-    "prepublishOnly": "npm run build",
     "start": "vue-cli-service serve",
     "build": "vue-cli-service build --name esco --target wc 'src/components/*.vue'",
     "lint": "vue-cli-service lint"

--- a/@uportal/eyebrow-user-info/package.json
+++ b/@uportal/eyebrow-user-info/package.json
@@ -2,7 +2,6 @@
   "name": "@uportal/eyebrow-user-info",
   "version": "1.13.2",
   "scripts": {
-    "prepublishOnly": "npm run build",
     "start": "vue-cli-service serve",
     "prebuild": "babel node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js -o node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js",
     "build": "vue-cli-service build --name eyebrow-user-info --target wc './src/components/EyebrowUserInfo.vue'",

--- a/@uportal/open-id-connect/package.json
+++ b/@uportal/open-id-connect/package.json
@@ -34,7 +34,6 @@
     "access": "public"
   },
   "scripts": {
-    "prepublishOnly": "npm run build",
     "build": "rollup -c",
     "test": "jest"
   },

--- a/@uportal/portlet-registry-to-array/package.json
+++ b/@uportal/portlet-registry-to-array/package.json
@@ -34,7 +34,6 @@
     "access": "public"
   },
   "scripts": {
-    "prepublishOnly": "npm run build",
     "build": "rollup -c",
     "test": "jest"
   },

--- a/@uportal/waffle-menu/package.json
+++ b/@uportal/waffle-menu/package.json
@@ -24,7 +24,6 @@
     "shx": "^0.3.1"
   },
   "scripts": {
-    "prepublishOnly": "npm run build",
     "start": "react-scripts start",
     "build": "react-scripts build && shx mv build/static/js/*.js build/static/js/waffle-menu.js"
   },

--- a/docs/en/developer/RELEASE.md
+++ b/docs/en/developer/RELEASE.md
@@ -2,13 +2,18 @@
 
 1. `git pull upstream master`
    - synchronizes with latest official version
-2. Update the "unreleased" section of `CHANGELOG.md` with an overview of changes
+2. Update the "unreleased" section of _CHANGELOG.md_ with an overview of changes
 3. `npm run build`
    - build needs to happen before `publish` because it takes longer than the 30s otp timeout
-4. `lerna version --conventional-commits --force-publish`
+4. `lerna version {patch or minor or major}`
    - determine new release number based off commit messages
-   - applies version number to all the packages
+     - `patch` for a release containing no `feat` or `BREAKING CHANGE` commits
+     - `minor` for a release containing `feat` but no `BREAKING CHANGE` commits
+     - `major` for a release containing `BREAKING CHANGE` commits
 5. `NPM_CONFIG_OTP={npm otp token} lerna publish from-git`
    - :notebook: This module requires [two factor authentication][] to cut a release
+6. `git push upstream master`
+7. `git push upstream --tags`
+8. Add a new release header to _CHANGELOG.md_
 
 [two factor authentication]: https://docs.npmjs.com/getting-started/using-two-factor-authentication

--- a/docs/en/developer/RELEASE.md
+++ b/docs/en/developer/RELEASE.md
@@ -1,9 +1,13 @@
 # Releasing uPortal-web-components
 
 1. `git pull upstream master`
+   - synchronizes with latest official version
 2. Update the "unreleased" section of `CHANGELOG.md` with an overview of changes
 3. `npm run build`
+   - build needs to happen before `publish` because it takes longer than the 30s otp timeout
 4. `lerna version --conventional-commits --force-publish`
+   - determine new release number based off commit messages
+   - applies version number to all the packages
 5. `NPM_CONFIG_OTP={npm otp token} lerna publish from-git`
    - :notebook: This module requires [two factor authentication][] to cut a release
 

--- a/docs/en/developer/RELEASE.md
+++ b/docs/en/developer/RELEASE.md
@@ -1,0 +1,10 @@
+# Releasing uPortal-web-components
+
+1. `git pull upstream master`
+2. Update the "unreleased" section of `CHANGELOG.md` with an overview of changes
+3. `npm run build`
+4. `lerna version --conventional-commits --force-publish`
+5. `NPM_CONFIG_OTP={npm otp token} lerna publish from-git`
+   - :notebook: This module requires [two factor authentication][] to cut a release
+
+[two factor authentication]: https://docs.npmjs.com/getting-started/using-two-factor-authentication

--- a/docs/en/developer/RELEASE.md
+++ b/docs/en/developer/RELEASE.md
@@ -11,9 +11,13 @@
      - `minor` for a release containing `feat` but no `BREAKING CHANGE` commits
      - `major` for a release containing `BREAKING CHANGE` commits
 5. `NPM_CONFIG_OTP={npm otp token} lerna publish from-git`
+   - pushes release to npm
    - :notebook: This module requires [two factor authentication][] to cut a release
 6. `git push upstream master`
+   - push release commit
 7. `git push upstream --tags`
+   - push release tag
 8. Add a new release header to _CHANGELOG.md_
+   - also update the links at the bottom of the page
 
 [two factor authentication]: https://docs.npmjs.com/getting-started/using-two-factor-authentication

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,7 @@
   "lerna": "3.4.0",
   "packages": ["@uportal/*"],
   "version": "1.13.2",
-  "requireScripts": true
+  "command": {
+    "version": { "forcePublish": true }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap --ci",
+    "build": "lerna run build",
     "ci:commitlint": "commitlint-travis",
     "format": "npm-run-all format:*",
     "format:js": "prettier-eslint --write '**/*.{js,vue}'",


### PR DESCRIPTION
Why?

* The build now takes longer than 30 seconds, the publish step uses a one time password (otp) to verify the publisher, the otp lasts only 30 seconds, meaning the publish will partially fail or completely fail.
* Conventional commits can be used to determine next version, this automates the version number process.
* Documents the process so hopefully more people can cut releases going forward.