### PR TITLE
fix(waffle-menu): web component standard version 1 support

### DIFF
--- a/@uportal/waffle-menu/package-lock.json
+++ b/@uportal/waffle-menu/package-lock.json
@@ -1,9 +1,14 @@
 {
   "name": "@uportal/waffle-menu",
-  "version": "1.13.2",
+  "version": "1.13.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@christianmurphy/reactive-elements": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@christianmurphy/reactive-elements/-/reactive-elements-1.0.3.tgz",
+      "integrity": "sha512-K++jEEBfgSE7qLbwTnFQ5J8/tAgpRkvibM0bQi0XqwS+HuI7wbpOEHpT0oi3vDn2i0ARe9T39NXgDfCHRQZXsw=="
+    },
     "@emotion/is-prop-valid": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
@@ -49,6 +54,23 @@
       "requires": {
         "humps": "^2.0.1",
         "prop-types": "^15.5.10"
+      }
+    },
+    "@uportal/open-id-connect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@uportal/open-id-connect/-/open-id-connect-1.13.4.tgz",
+      "integrity": "sha512-2SGxST4QzExrXtY9reMDuyEr5X/8PEwV8tkbvq1xam8YVr58wTh16h5+1xcZ0rO2ZUgxU8YdmoEkFgm1qXR2zA==",
+      "requires": {
+        "axios": "^0.18.0",
+        "jwt-decode": "^2.2.0"
+      }
+    },
+    "@uportal/portlet-registry-to-array": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@uportal/portlet-registry-to-array/-/portlet-registry-to-array-1.13.4.tgz",
+      "integrity": "sha512-Hkf6mc9ZF5zVArs4jIORsUOqd+9T39JGeNC8r+MMFw70LsWmPp0GtZiNzgaDvykhBjM0v08nUackQm7FKBhpWw==",
+      "requires": {
+        "lodash.uniqby": "^4.7.0"
       }
     },
     "abab": {
@@ -454,6 +476,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
     },
     "axobject-query": {
       "version": "0.1.0",
@@ -4405,7 +4436,6 @@
       "version": "1.5.8",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
       "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
-      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -4414,7 +4444,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4522,8 +4551,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4544,14 +4572,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4566,20 +4592,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4696,8 +4719,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4709,7 +4731,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4724,7 +4745,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4732,14 +4752,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4758,7 +4776,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4839,8 +4856,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4852,7 +4868,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4938,8 +4953,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4975,7 +4989,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4995,7 +5008,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5039,14 +5051,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5850,8 +5860,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -6742,6 +6751,11 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -6973,6 +6987,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "loglevel": {
       "version": "1.6.1",
@@ -7287,8 +7306,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/@uportal/waffle-menu/package.json
+++ b/@uportal/waffle-menu/package.json
@@ -8,6 +8,7 @@
   "main": "build/static/js/waffle-menu.js",
   "source": "src/WaffleMenu.js",
   "dependencies": {
+    "@christianmurphy/reactive-elements": "^1.0.3",
     "@uportal/open-id-connect": "^1.13.4",
     "@uportal/portlet-registry-to-array": "^1.13.4",
     "lodash.get": "^4.4.2",

--- a/@uportal/waffle-menu/public/index.html
+++ b/@uportal/waffle-menu/public/index.html
@@ -7,6 +7,7 @@
   <meta name="theme-color" content="#000000">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+  <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <title>Waffle Menu</title>
   <style>
     /* basic styles for showing waffle menu in the header of a site */

--- a/@uportal/waffle-menu/src/index.js
+++ b/@uportal/waffle-menu/src/index.js
@@ -1,5 +1,5 @@
 import WaffleMenu from './WaffleMenu';
 import 'document-register-element';
-import RegisterReact from 'reactive-elements';
+import registerReact from '@christianmurphy/reactive-elements';
 
-RegisterReact.registerReact('waffle-menu', WaffleMenu);
+registerReact('waffle-menu', WaffleMenu);


### PR DESCRIPTION
temporarily switches to a fork of reactive elements until an official version is released.

fixes #86