### PR TITLE
refactor: extract polyfills

### DIFF
--- a/@uportal/content-carousel/babel.config.js
+++ b/@uportal/content-carousel/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function(api) {
   api.cache.never();
   return {
     plugins: ['babel-plugin-transform-custom-element-classes'],
-    presets: ['@vue/app'],
+    presets: [['@vue/app', {useBuiltIns: false}]],
   };
 };

--- a/@uportal/esco-content-menu/babel.config.js
+++ b/@uportal/esco-content-menu/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  presets: ['@vue/app'],
+  presets: [['@vue/app', {useBuiltIns: false}]],
   plugins: [
     '@babel/plugin-proposal-optional-chaining',
     'babel-plugin-transform-custom-element-classes',

--- a/@uportal/esco-content-menu/src/i18n.js
+++ b/@uportal/esco-content-menu/src/i18n.js
@@ -1,5 +1,3 @@
-import 'core-js/fn/array/flat-map';
-
 import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 

--- a/@uportal/eyebrow-user-info/babel.config.js
+++ b/@uportal/eyebrow-user-info/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function(api) {
   api.cache.never();
   return {
     plugins: ['babel-plugin-transform-custom-element-classes'],
-    presets: ['@vue/app'],
+    presets: [['@vue/app', {useBuiltIns: false}]],
   };
 };

--- a/@uportal/eyebrow-user-info/src/i18n.js
+++ b/@uportal/eyebrow-user-info/src/i18n.js
@@ -1,5 +1,3 @@
-import 'core-js/fn/array/flat-map';
-
 import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 

--- a/@uportal/open-id-connect/babel.config.js
+++ b/@uportal/open-id-connect/babel.config.js
@@ -1,13 +1,6 @@
 module.exports = function(api) {
   api.cache.never();
   return {
-    presets: [
-      [
-        '@babel/preset-env',
-        {
-          useBuiltIns: 'usage',
-        },
-      ],
-    ],
+    presets: ['@babel/preset-env'],
   };
 };

--- a/@uportal/portlet-registry-to-array/babel.config.js
+++ b/@uportal/portlet-registry-to-array/babel.config.js
@@ -1,13 +1,6 @@
 module.exports = function(api) {
   api.cache.never();
   return {
-    presets: [
-      [
-        '@babel/preset-env',
-        {
-          useBuiltIns: 'usage',
-        },
-      ],
-    ],
+    presets: ['@babel/preset-env'],
   };
 };


### PR DESCRIPTION
expect adopters to apply the polyfills they want/need to the page.
E.G. uPortal now includes webcomponentsjs, core-js, and regenerator-runtime by default.