### PR TITLE
fix(eyebrow-user-info): vue@cli-service error due to babel helper

### DIFF
--- a/@uportal/eyebrow-user-info/babel.config.js
+++ b/@uportal/eyebrow-user-info/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function(api) {
   api.cache.never();
   return {
     plugins: ['babel-plugin-transform-custom-element-classes'],
-    presets: [['@vue/app', {useBuiltIns: false}]],
+    presets: ['@vue/app'],
   };
 };


### PR DESCRIPTION
The build since `vue@cli-service` update to version 3.0.5 doesn't work as expected, it produce a not working component.
The change into `cli-service` is related to [this commit](https://github.com/vuejs/vue-cli/commit/da649385501ff1a9a75bbf286c9f03b14ddce4f1) which is related to [this issue](https://github.com/vuejs/vue-cli/issues/2637)