### PR TITLE
fix: prettier-stylelint isn't active and cause problems on scss files

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,13 @@
       "tslint -c tslint.json --fix",
       "git add"
     ],
-    "*.{css,scss}": [
+    "*.css": [
       "prettier-stylelint --write",
+      "git add"
+    ],
+    "*.scss": [
+      "prettier --write --parser scss",
+      "stylelint",
       "git add"
     ],
     "*.{md,json}": [


### PR DESCRIPTION
`prettier-stylelint --write` rewrite on empty scss files so I moved to prettier native command for such files.

Also a warning about prettier-stylelint, it doesn't have any more activity (1 year last activity), it use a deprecated command postcss. Instead use a such command (the parser option seems not needed on last version of prettier)
```
$ prettier --write --parser scss ./file.scss
$ prettier --write --parser css ./file.css
```
I didn't find an other tool for scss files.