### PR TITLE
docs(content-carousel): include slick stylesheet in examples

### DIFF
--- a/@uportal/content-carousel/README.md
+++ b/@uportal/content-carousel/README.md
@@ -39,6 +39,7 @@ compile 'org.webjars.npm:uportal__content-carousel:{version number goes here}'
 The component requires a type. It also allows for a `carousel-height` (in rem units), a `fit-to-container` property which causes it to size to its container (horizontally), and `slick-options`.
 
 ```html
+<link href="https://unpkg.com/slick-carousel@1.8.1/slick/slick-theme.css" rel="stylesheet">
 <script src="https://unpkg.com/vue"></script>
 <script src="https://unpkg.com/@uportal/content-carousel"></script>
 

--- a/docs/en/components/content-carousel/demo.html
+++ b/docs/en/components/content-carousel/demo.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>content-carousel demo</title>
+    <link href="https://unpkg.com/slick-carousel@1.8.1/slick/slick-theme.css" rel="stylesheet">
   </head>
   <body>
     <content-carousel


### PR DESCRIPTION
stylesheet is needed to correctly apply font face needed by the component.

resolves #85
closes #147