### PR TITLE
 fix: manually tree shake font awesome icons

### DIFF
--- a/@uportal/esco-content-menu/src/icons.js
+++ b/@uportal/esco-content-menu/src/icons.js
@@ -1,14 +1,12 @@
 import {library} from '@fortawesome/fontawesome-svg-core';
-import {faStar as faStarRegular} from '@fortawesome/free-regular-svg-icons';
-import {
-  faChevronLeft,
-  faChevronRight,
-  faExchangeAlt,
-  faSignOutAlt,
-  faStar as faStarSolid,
-  faTimes,
-  faUser,
-} from '@fortawesome/free-solid-svg-icons';
+import {faStar as faStarRegular} from '@fortawesome/free-regular-svg-icons/faStar';
+import {faChevronLeft} from '@fortawesome/free-solid-svg-icons/faChevronLeft';
+import {faChevronRight} from '@fortawesome/free-solid-svg-icons/faChevronRight';
+import {faExchangeAlt} from '@fortawesome/free-solid-svg-icons/faExchangeAlt';
+import {faSignOutAlt} from '@fortawesome/free-solid-svg-icons/faSignOutAlt';
+import {faStar as faStarSolid} from '@fortawesome/free-solid-svg-icons/faStar';
+import {faTimes} from '@fortawesome/free-solid-svg-icons/faTimes';
+import {faUser} from '@fortawesome/free-solid-svg-icons/faUser';
 
 if (process.env.NODE_ENV === 'development') {
   console.log(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][]
 
+## [1.15.0][] - 2018-10-29
+
 ### Feature
 
 - **esco-content-menu**: allow portlets to be added to favorites in small mode (#143)
@@ -594,7 +596,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **open-id-connect**: Initial version of an OpenID Connect helper script to use in web components and JavaScript modules.
 - **content-carousel**: Initial version of content carousel, a carousel based portlet metadata display system.
 
-[unreleased]: https://github.com/uPortal-contrib/uPortal-web-components/compare/v1.14.2...HEAD
+[unreleased]: https://github.com/uPortal-contrib/uPortal-web-components/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/uPortal-contrib/uPortal-web-components/compare/v1.14.2...v1.15.0
 [1.14.2]: https://github.com/uPortal-contrib/uPortal-web-components/compare/v1.14.1...v1.14.2
 [1.14.1]: https://github.com/uPortal-contrib/uPortal-web-components/compare/v1.14.0...v1.14.1
 [1.14.0]: https://github.com/uPortal-contrib/uPortal-web-components/compare/v1.13.7...v1.14.0


### PR DESCRIPTION
webpack was not correctly identinifying unused icons, leading to 700kb of unused icons being included in package.
See: https://github.com/FortAwesome/vue-fontawesome#tree-shaking-alternative