### PR TITLE
feat(esco-content-menu): support sort by custom portlet order

### DIFF
--- a/@uportal/esco-content-menu/public/browseable.json
+++ b/@uportal/esco-content-menu/public/browseable.json
@@ -16,7 +16,8 @@
         "iconUrl": null,
         "nodeId": "-1",
         "parameters": {
-          "disableDynamicTitle": "true"
+          "disableDynamicTitle": "true",
+          "escoMenuOrder": "2"
         },
         "pithyStaticContent": null,
         "renderOnWeb": false,
@@ -63,7 +64,8 @@
         "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png",
         "nodeId": "-1",
         "parameters": {
-          "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+          "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png",
+          "escoMenuOrder": "1"
         },
         "pithyStaticContent": null,
         "renderOnWeb": false,

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -72,6 +72,7 @@
 import i18n from '../i18n.js';
 import PortletCard from './PortletCard';
 import fetchPortlets from '../services/fetchPortlets';
+import byPortlet from '../services/sortByPortlet';
 import {
   elementWidth,
   breakPointName,
@@ -186,7 +187,8 @@ export default {
       return this.favorites.includes(fname);
     },
     async fetchPortlets() {
-      this.portletsAPI = await fetchPortlets(this.contextApiUrl);
+      const portlets = await fetchPortlets(this.contextApiUrl);
+      this.portletsAPI = portlets.sort(byPortlet);
     },
     calculateSize() {
       this.elementSize = breakPointName(elementWidth(this.$el));

--- a/@uportal/esco-content-menu/src/services/sortByPortlet.js
+++ b/@uportal/esco-content-menu/src/services/sortByPortlet.js
@@ -1,0 +1,26 @@
+export default function(a, b) {
+  const aCustomOrder = parseInt(a?.layoutObject?.parameters?.escoMenuOrder, 10);
+  const bCustomOrder = parseInt(b?.layoutObject?.parameters?.escoMenuOrder, 10);
+
+  // if neither has a custom order, sort by title
+  if (isNaN(aCustomOrder) && isNaN(bCustomOrder)) {
+    return a.title
+        .trim()
+        .toLowerCase()
+        .localeCompare(b.title.trim().toLowerCase(), undefined, {
+          numberic: true,
+        });
+  }
+
+  // sort the items with custom order, in front of items without
+  if (isNaN(aCustomOrder)) {
+    return 1;
+  }
+  if (isNaN(bCustomOrder)) {
+    return -1;
+  }
+
+  // both items are custom, sort using the number line
+  // lower numbers first, higher numbers after
+  return aCustomOrder - bCustomOrder;
+}

--- a/@uportal/esco-content-menu/src/services/sortByPortlet.js
+++ b/@uportal/esco-content-menu/src/services/sortByPortlet.js
@@ -1,4 +1,5 @@
 export default function(a, b) {
+  // if parameter is missing or an invalid integer, Not a Number (NaN) will be set
   const aCustomOrder = parseInt(a?.layoutObject?.parameters?.escoMenuOrder, 10);
   const bCustomOrder = parseInt(b?.layoutObject?.parameters?.escoMenuOrder, 10);
 
@@ -12,7 +13,7 @@ export default function(a, b) {
         });
   }
 
-  // sort the items with custom order, in front of items without
+  // sort the items with custom order in front of items without
   if (isNaN(aCustomOrder)) {
     return 1;
   }


### PR DESCRIPTION
if an "escoMenuOrder" parameter is provided that will be used to sort the element.
If no custom order is provided it will sort by the title in the browsers current locale.
When there is a mix of custom order and title order, custom order will be moved in front of title order.