### PR TITLE
feat(esco-content-menu): allow favorites to update when grid is run independently

### DIFF
--- a/@uportal/esco-content-menu/src/App.vue
+++ b/@uportal/esco-content-menu/src/App.vue
@@ -8,7 +8,7 @@
       hide-action-mode="never" />
       <!--<hamburger-menu-->
       <!--default-org-logo="https://lycees.netocentre.fr/annuaire_images/default_banner_v1.jpg" />-->
-      <!--<content-grid-->
+      <!-- <content-grid/> -->
       <!--background-color="grey"-->
       <!--portlet-card-size="medium" />-->
   </div>

--- a/@uportal/esco-content-menu/src/components/ActionFavorites.vue
+++ b/@uportal/esco-content-menu/src/components/ActionFavorites.vue
@@ -57,10 +57,10 @@ export default {
     };
   },
   methods: {
-    translate: function(text, lang) {
+    translate(text, lang) {
       return i18n.t(text, lang);
     },
-    toggleFavorite: function(event) {
+    toggleFavorite(event) {
       event.preventDefault();
       if (process.env.NODE_ENV !== 'development') {
         if (this.favorite) {
@@ -73,12 +73,12 @@ export default {
       }
       return false;
     },
-    changeFavoriteValue: function() {
+    changeFavoriteValue() {
       this.favorite = !this.favorite;
       this.$emit('is-favorite', this.favorite);
-      this.callOnToggleFav(this.favorite, this.fname);
+      this.callOnToggleFav(this.fname);
     },
-    addToFavorite: function() {
+    addToFavorite() {
       oidc({userInfoApiUrl: this.userInfoApiUrl})
           .then((token) => {
             const options = {
@@ -101,7 +101,7 @@ export default {
           })
           .catch((err) => console.error('Error, with message:', err.statusText));
     },
-    removeFromFavorite: function() {
+    removeFromFavorite() {
       oidc({userInfoApiUrl: this.userInfoApiUrl})
           .then((token) => {
             const options = {

--- a/@uportal/esco-content-menu/src/components/ContentFavorites.vue
+++ b/@uportal/esco-content-menu/src/components/ContentFavorites.vue
@@ -132,27 +132,27 @@ export default {
   },
   watch: {
     favorites: {
-      handler: function() {
+      handler() {
         this.calcFavoritesPortlets();
         this.updateSlider();
       },
       deep: true,
     },
     portlets: {
-      handler: function() {
+      handler() {
         this.calcFavoritesPortlets();
         this.updateSlider();
       },
       deep: true,
     },
     favorited: {
-      handler: function() {
+      handler() {
         this.updateSlider();
       },
       deep: true,
     },
     isHidden: {
-      handler: function() {
+      handler() {
         this.updateSlider();
       },
       deep: true,
@@ -164,14 +164,14 @@ export default {
     });
   },
   computed: {
-    _portletCardSize: function() {
+    _portletCardSize() {
       if (this.portletCardSize === 'auto') {
         return this.calculatedSize;
       } else return this.portletCardSize;
     },
   },
   methods: {
-    translate: function(text, lang) {
+    translate(text, lang) {
       return i18n.t(text, lang);
     },
     computeImgUrl(url) {
@@ -234,7 +234,7 @@ export default {
         }
       }
     },
-    emptyArray: function(array) {
+    emptyArray(array) {
       while (array.length > 0) {
         array.pop();
       }

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -89,7 +89,7 @@ export default {
   },
   props: {
     backgroundColor: {type: String, default: 'rgba(0, 0, 0, 0)'},
-    callAfterAction: {type: Function},
+    callAfterAction: {type: Function, default: undefined},
     favoriteApiUrl: {
       type: String,
       default:

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -58,7 +58,7 @@
               :is-favorite="isFavorite(portlet.fname)"
               :size="_portletCardSize"
               :hide-action="hideAction"
-              :call-after-action="callAfterAction"
+              :call-after-action="actionToggleFav"
               :favorite-api-url="favoriteApiUrl"
               :user-info-api-url="userInfoApiUrl" />
           </a>
@@ -75,6 +75,7 @@ import fetchPortlets from '../services/fetchPortlets';
 import byPortlet from '../services/sortByPortlet';
 import fetchFavorites from '../services/fetchFavorites';
 import flattenFavorites from '../services/flattenFavorites';
+import toggleArray from '../services/toggleArray';
 import {
   elementWidth,
   breakPointName,
@@ -88,7 +89,7 @@ export default {
   },
   props: {
     backgroundColor: {type: String, default: 'rgba(0, 0, 0, 0)'},
-    callAfterAction: {type: Function, default: () => {}},
+    callAfterAction: {type: Function},
     favoriteApiUrl: {
       type: String,
       default:
@@ -195,6 +196,12 @@ export default {
     },
     calculateSize() {
       this.elementSize = breakPointName(elementWidth(this.$el));
+    },
+    actionToggleFav(fname) {
+      if (this.callAfterAction) {
+        return this.callAfterAction(fname);
+      }
+      this.favorites = toggleArray(this.favorites, fname);
     },
   },
 };

--- a/@uportal/esco-content-menu/src/components/ContentMenu.vue
+++ b/@uportal/esco-content-menu/src/components/ContentMenu.vue
@@ -53,6 +53,7 @@ import fetchPortlets from '../services/fetchPortlets';
 import fetchFavorites from '../services/fetchFavorites';
 import flattenFavorites from '../services/flattenFavorites';
 import byPortlet from '../services/sortByPortlet';
+import toggleArray from '../services/toggleArray';
 import {
   elementWidth,
   breakPointName,
@@ -123,13 +124,13 @@ export default {
     };
   },
   computed: {
-    _portlets: function() {
+    _portlets() {
       return this.portletsAPI;
     },
   },
   watch: {
     isHidden: {
-      handler: function() {
+      handler() {
         this.visible = !this.isHidden;
         if (this.visible) {
           this.minHeight = document.body.getBoundingClientRect().height + 'px';
@@ -159,7 +160,7 @@ export default {
       this.isHidden = false;
       this.callOnClose(event);
     },
-    calculateSize: function() {
+    calculateSize() {
       this.screenSize = breakPointName(elementWidth(this.$el));
 
       switch (this.hideActionMode) {
@@ -175,7 +176,7 @@ export default {
           this.hideAction = true;
       }
     },
-    computeCurrentOrg: function() {
+    computeCurrentOrg() {
       if (
         this.info.user &&
         this.info.user.ESCOSIRENCourant &&
@@ -256,14 +257,8 @@ export default {
       const favoritesTree = await fetchFavorites(this.contextApiUrl);
       this.info.favorites = flattenFavorites(favoritesTree);
     },
-    actionToggleFav(isAddFavorite, fname) {
-      if (isAddFavorite) {
-        this.info.favorites.push(fname);
-      } else {
-        this.info.favorites = this.info.favorites.filter(
-            (value) => value !== fname
-        );
-      }
+    actionToggleFav(fname) {
+      this.info.favorites = toggleArray(this.info.favorites, fname);
     },
   },
 };

--- a/@uportal/esco-content-menu/src/components/Ellipsis.vue
+++ b/@uportal/esco-content-menu/src/components/Ellipsis.vue
@@ -17,7 +17,7 @@ export default {
   },
   watch: {
     message: {
-      handler: function() {
+      handler() {
         this.calcFavoritesPortlets();
       },
     },

--- a/@uportal/esco-content-menu/src/services/toggleArray.js
+++ b/@uportal/esco-content-menu/src/services/toggleArray.js
@@ -1,0 +1,9 @@
+export default function toggleArray(array, value) {
+  const index = array.indexOf(value);
+  if (index > -1) {
+    array.splice(index, 1);
+    return array;
+  } else {
+    return array.concat(value);
+  }
+}


### PR DESCRIPTION
Full suite of components still work together
![full-mode-works](https://user-images.githubusercontent.com/3107513/48668132-3c7a0a80-eaa3-11e8-80bb-2e41ebdf5b96.gif)

Grid can now update favorites icon when running independent of menu
![grid-mode-works](https://user-images.githubusercontent.com/3107513/48668133-3e43ce00-eaa3-11e8-842f-37afca3e394d.gif)
