### PR TITLE
docs: add Jeff Sittler to committers

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -12,7 +12,7 @@ With the addition of the following committers:
 
 - Chris Beach (@cbeach47)
 - Chris Paraiso (@cparaiso)
-- Julien Gribonvald (@gribonvald)
+- Jeff Sittler (@mindblender)
 - Phillip Ball (@illiphilli)
 - Ryan Mathis (@rmathis)
 


### PR DESCRIPTION
Removed Julien from additional contributor list, he now has access through the uPortal committer list.

//cc @mindblender