### PR TITLE
feat(eco-content-menu): retrieve configurable deep attributes

### DIFF
--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -69,9 +69,9 @@ For some integration you could need a bit more, like into uPortal you will need 
 - `favorites-portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of portlet-cards component into `favorite-content` component part,
 - `grid-portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of `portlet-cards` component into `grid-content` component part,
 - `hide-action-mode: type`: possible value `auto|always|never`, default: `auto`, define if we should show the actions, `auto` don't show on `small` breakpoint,
-- `user-org-id-attribute-name`: type: `String`, default: `'ESCOSIRENCourant'`, the attribute to use to obtain the id of the organization to retrieve from the organization's api
-- `user-all-orgs-id-attribute-name`: type: `String`, default: `'ESCOSIREN`, the attribute to use to obtain all ids of the organizations linked to the user and to retrieve from the organization's api
-- `org-logo-url-attribute-name`: type: `String`, default: `'ESCOStructureLogo'`, the attribute to use to obtain the organization Picture from organization details obtained from the organization's api.
+- `user-org-id-attribute-name`: type: `String`, default: `'ESCOSIRENCourant[0]'`, the attribute object path to obtain the id of the organization to retrieve from the organization's api
+- `user-all-orgs-id-attribute-name`: type: `String`, default: `'ESCOSIREN`, the attribute object path to obtain all ids of the organizations linked to the user and to retrieve from the organization's api
+- `org-logo-url-attribute-name`: type: `String`, default: `'otherAttributes.ESCOStructureLogo[0]'`, the attribute object path to obtain the organization Picture from organization details obtained from the organization's api.
 
 ### The content menu
 
@@ -207,6 +207,7 @@ Need some work for a standalone use.
 - `switch-org-portlet-url`: type: `String`, default: `'''`, an url/uri where the user can switch of organization when having several (tenant use part),
 - `default-org-logo`: type: `String`, required: `true`, an url/uri to provide an institutional picture when none is found from an optional api (not provided into uPortal),
 - `user-info-portlet-url`: type: `String`, default: `''`, an url/uri to the user information application,
+- `org-logo-url-attribute-name`: type: `String`, default: `'otherAttributes.ESCOStructureLogo[0]'`, the attribute object path to obtain the organization Picture from organization details obtained from the organization's api.
 
 and additional properties to work with the parent component `content-menu`:
 

--- a/@uportal/esco-content-menu/package-lock.json
+++ b/@uportal/esco-content-menu/package-lock.json
@@ -6494,8 +6494,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/@uportal/esco-content-menu/package.json
+++ b/@uportal/esco-content-menu/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.0.0",
     "@uportal/open-id-connect": "^1.18.2",
+    "lodash": "^4.17.11",
     "vue": "^2.5.17",
     "vue-awesome-swiper": "^3.1.3",
     "vue-i18n": "^8.2.1",

--- a/@uportal/esco-content-menu/src/components/ContentMenu.vue
+++ b/@uportal/esco-content-menu/src/components/ContentMenu.vue
@@ -103,9 +103,12 @@ export default {
       validator: (value) => ['auto', 'always', 'never'].includes(value),
       default: 'auto',
     },
-    userOrgIdAttributeName: {type: String, default: 'ESCOSIRENCourant'},
+    userOrgIdAttributeName: {type: String, default: 'ESCOSIRENCourant[0]'},
     userAllOrgsIdAttributeName: {type: String, default: 'ESCOSIREN'},
-    orgLogoUrlAttributeName: {type: String, default: 'ESCOStructureLogo'},
+    orgLogoUrlAttributeName: {
+      type: String,
+      default: 'otherAttributes.ESCOStructureLogo[0]',
+    },
   },
   data() {
     return {

--- a/@uportal/esco-content-menu/src/components/ContentUser.vue
+++ b/@uportal/esco-content-menu/src/components/ContentUser.vue
@@ -84,7 +84,10 @@ export default {
     },
     defaultOrgLogo: {type: String, required: true},
     userInfoPortletUrl: {type: String, default: ''},
-    orgLogoUrlAttributeName: {type: String, default: 'ESCOStructureLogo'},
+    orgLogoUrlAttributeName: {
+      type: String,
+      default: 'otherAttributes.ESCOStructureLogo[0]',
+    },
   },
   methods: {
     translate(text, lang) {

--- a/@uportal/esco-content-menu/src/components/HamburgerMenu.vue
+++ b/@uportal/esco-content-menu/src/components/HamburgerMenu.vue
@@ -67,9 +67,12 @@ export default {
       validator: (value) => ['auto', 'always', 'never'].includes(value),
       default: 'auto',
     },
-    userOrgIdAttributeName: {type: String, default: 'ESCOSIRENCourant'},
+    userOrgIdAttributeName: {type: String, default: 'ESCOSIRENCourant[0]'},
     userAllOrgsIdAttributeName: {type: String, default: 'ESCOSIREN'},
-    orgLogoUrlAttributeName: {type: String, default: 'ESCOStructureLogo'},
+    orgLogoUrlAttributeName: {
+      type: String,
+      default: 'otherAttributes.ESCOStructureLogo[0]',
+    },
   },
   data() {
     return {

--- a/@uportal/esco-content-menu/src/services/fetchUserInfoAndOrgs.js
+++ b/@uportal/esco-content-menu/src/services/fetchUserInfoAndOrgs.js
@@ -1,5 +1,5 @@
 import oidc from '@uportal/open-id-connect';
-import _ from 'lodash';
+import get from 'lodash/get';
 
 export default async function(contextApiUrl, userAllOrgIdAttribute) {
   if (process.env.NODE_ENV === 'development') {
@@ -19,7 +19,7 @@ export default async function(contextApiUrl, userAllOrgIdAttribute) {
       const {encoded, decoded} = await oidc({
         userInfoApiUrl: contextApiUrl + process.env.VUE_APP_USER_INFO_URI,
       });
-      const orgIds = _.get(decoded, userAllOrgIdAttribute, null);
+      const orgIds = get(decoded, userAllOrgIdAttribute, null);
       if (orgIds?.length > 0) {
         const options = {
           method: 'GET',

--- a/@uportal/esco-content-menu/src/services/fetchUserInfoAndOrgs.js
+++ b/@uportal/esco-content-menu/src/services/fetchUserInfoAndOrgs.js
@@ -1,6 +1,7 @@
 import oidc from '@uportal/open-id-connect';
+import _ from 'lodash';
 
-export default async function(contextApiUrl, userOrgIdAttribute) {
+export default async function(contextApiUrl, userAllOrgIdAttribute) {
   if (process.env.NODE_ENV === 'development') {
     const userInfoRequest = await fetch('userinfo.json');
     const orgsInfoRequest = await fetch('orginfo.json');
@@ -18,7 +19,8 @@ export default async function(contextApiUrl, userOrgIdAttribute) {
       const {encoded, decoded} = await oidc({
         userInfoApiUrl: contextApiUrl + process.env.VUE_APP_USER_INFO_URI,
       });
-      if (decoded && decoded[userOrgIdAttribute]?.length > 0) {
+      const orgIds = _.get(decoded, userAllOrgIdAttribute, null);
+      if (orgIds?.length > 0) {
         const options = {
           method: 'GET',
           credentials: 'same-origin',
@@ -31,7 +33,7 @@ export default async function(contextApiUrl, userOrgIdAttribute) {
             process.env.VUE_APP_PORTAL_BASE_URL +
             process.env.VUE_APP_ORG_INFO_URI +
             '?ids=' +
-            decoded[userOrgIdAttribute],
+            orgIds,
             options
         );
         if (!response.ok) {

--- a/@uportal/esco-content-menu/src/services/organizationHelper.js
+++ b/@uportal/esco-content-menu/src/services/organizationHelper.js
@@ -1,12 +1,13 @@
+import _ from 'lodash';
+
 export function getCurrentOrganization(
     user,
     userOrgIdAttribute,
     organizations
 ) {
-  if (user && user[userOrgIdAttribute] && organizations?.length > 0) {
-    return organizations.find(
-        (entry) => entry.id === user[userOrgIdAttribute][0]
-    );
+  const currentUserOrgId = _.get(user, userOrgIdAttribute, null);
+  if (_.isString(currentUserOrgId) && organizations?.length > 0) {
+    return organizations.find((entry) => entry.id === currentUserOrgId);
   } else if (organizations?.length > 0) {
     return organizations[0];
   }
@@ -14,15 +15,7 @@ export function getCurrentOrganization(
 }
 
 export function getOrganizationLogo(organization, attributeName) {
-  let entry = null;
-  if (organization && organization[attributeName]?.length > 0) {
-    entry = organization[attributeName];
-  } else if (
-    organization?.hasOwnProperty('otherAttributes') &&
-    organization.otherAttributes[attributeName]?.length > 0
-  ) {
-    entry = organization.otherAttributes[attributeName];
-  }
+  const entry = _.get(organization, attributeName, null);
   if (Array.isArray(entry)) {
     return entry[0];
   }

--- a/@uportal/esco-content-menu/src/services/organizationHelper.js
+++ b/@uportal/esco-content-menu/src/services/organizationHelper.js
@@ -1,12 +1,13 @@
-import _ from 'lodash';
+import get from 'lodash/get';
+import isString from 'lodash/isString';
 
 export function getCurrentOrganization(
     user,
     userOrgIdAttribute,
     organizations
 ) {
-  const currentUserOrgId = _.get(user, userOrgIdAttribute, null);
-  if (_.isString(currentUserOrgId) && organizations?.length > 0) {
+  const currentUserOrgId = get(user, userOrgIdAttribute, null);
+  if (isString(currentUserOrgId) && organizations?.length > 0) {
     return organizations.find((entry) => entry.id === currentUserOrgId);
   } else if (organizations?.length > 0) {
     return organizations[0];
@@ -15,7 +16,7 @@ export function getCurrentOrganization(
 }
 
 export function getOrganizationLogo(organization, attributeName) {
-  const entry = _.get(organization, attributeName, null);
+  const entry = get(organization, attributeName, null);
   if (Array.isArray(entry)) {
     return entry[0];
   }


### PR DESCRIPTION
Add a better way to configure attribute path from component props using lodash