### PR TITLE
build(dashboard-carousel): declare source and main files in package

### DIFF
--- a/@uportal/dashboard-carousel/package.json
+++ b/@uportal/dashboard-carousel/package.json
@@ -4,6 +4,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "main": "dist/dashboard-carousel.js",
+  "source": "src/components/dashboard-carousel.vue",
   "scripts": {
     "start": "vue-cli-service serve",
     "prebuild": "babel node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js -o node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js",


### PR DESCRIPTION
all the files are already present.
`main` provides a shortcut for npm and webjars to find the entrypoint without providing the full path.