### PR TITLE
feat(dashboard-carousel): configurable selected region

### DIFF
--- a/@uportal/dashboard-carousel/README.md
+++ b/@uportal/dashboard-carousel/README.md
@@ -42,5 +42,6 @@ compile 'org.webjars.npm:uportal__dashboard-carousel:{version number goes here}'
 
 ### Options
 
-- `debug` (optional, boolean, default false): when enabled debug mode skips oauth authentication.
+- `debug` (optional, boolean, default: false): when enabled debug mode skips oauth authentication.
 - `layout-api-url` (optional, string, default: "/uPortal/api/v4-3/dlm/layout.json"): url to layout for carousel to use.
+- `region` (optional, string, default: "dashboard"): name of the region in the layout that should be displayed.

--- a/@uportal/dashboard-carousel/README.md
+++ b/@uportal/dashboard-carousel/README.md
@@ -44,4 +44,4 @@ compile 'org.webjars.npm:uportal__dashboard-carousel:{version number goes here}'
 
 - `debug` (optional, boolean, default: false): when enabled debug mode skips oauth authentication.
 - `layout-api-url` (optional, string, default: "/uPortal/api/v4-3/dlm/layout.json"): url to layout for carousel to use.
-- `region` (optional, string, default: "dashboard"): name of the region in the layout that should be displayed.
+- `region-name` (optional, string, default: "dashboard"): name of the region in the layout that should be displayed.

--- a/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
+++ b/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
@@ -89,6 +89,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    region: {
+      type: String,
+      default: 'dashboard',
+    },
   },
   asyncComputed: {
     layout: {
@@ -131,7 +135,7 @@ export default {
         slick.goTo(currentIndex, true);
       });
       const dashboard = this.layout.layout.regions.find(
-          (region) => region.name === 'dashboard'
+          (region) => region.name === this.region
       );
 
       if (!dashboard) {

--- a/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
+++ b/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
@@ -89,7 +89,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    region: {
+    regionName: {
       type: String,
       default: 'dashboard',
     },
@@ -135,7 +135,7 @@ export default {
         slick.goTo(currentIndex, true);
       });
       const dashboard = this.layout.layout.regions.find(
-          (region) => region.name === this.region
+          (region) => region.name === this.regionName
       );
 
       if (!dashboard) {


### PR DESCRIPTION
Allow the selected region for the carousel to be configured via the `region` attribute on the element.