### PR TITLE
fix(esco-content-menu): revert css change from #197 but from parent

### DIFF
--- a/@uportal/esco-content-menu/src/components/ContentMenu.vue
+++ b/@uportal/esco-content-menu/src/components/ContentMenu.vue
@@ -401,6 +401,16 @@ export default {
         flex-flow: row wrap;
       }
     }
+
+    > /deep/ section.content-grid {
+      > div {
+        background-color: #f3f3f3;
+
+        > .title {
+          background-color: #fff;
+        }
+      }
+    }
   }
 }
 </style>


### PR DESCRIPTION
Reapply styling removed from #197, but apply it from parent as it depends on parent integration.

NOTE: '/deep/' is deprecated in css, but is converted by vue-loader and scss processor.