### PR TITLE
feat(content-carousel): implemented authenticated RSS strategy

### DIFF
--- a/@uportal/content-carousel/src/components/ContentCarousel.ts
+++ b/@uportal/content-carousel/src/components/ContentCarousel.ts
@@ -102,6 +102,7 @@ export default class ContentCarousel extends Vue {
       }
       case 'authenticated-rss': {
         this.strategy = new AuthenticatedRssStrategy(this.source);
+        break;
       }
       default: {
         console.error(`type: "${this.type}" is not recognized`);

--- a/@uportal/content-carousel/src/components/ContentCarousel.ts
+++ b/@uportal/content-carousel/src/components/ContentCarousel.ts
@@ -1,3 +1,4 @@
+import {AuthenticatedRssStrategy} from '@/lib/AuthenticatedRssStrategy';
 import {PortletStrategy} from '@/lib/PortletStrategy';
 import {RssStrategy} from '@/lib/RssStrategy';
 import {Component, Prop, Vue, Watch} from 'vue-property-decorator';
@@ -98,6 +99,9 @@ export default class ContentCarousel extends Vue {
         // ensure 'passthrough' is lowercase
         this.type = this.type.toLowerCase();
         break;
+      }
+      case 'authenticated-rss': {
+        this.strategy = new AuthenticatedRssStrategy(this.source);
       }
       default: {
         console.error(`type: "${this.type}" is not recognized`);

--- a/@uportal/content-carousel/src/lib/AuthenticatedRssStrategy.ts
+++ b/@uportal/content-carousel/src/lib/AuthenticatedRssStrategy.ts
@@ -17,8 +17,7 @@ export class AuthenticatedRssStrategy implements DataStrategy {
     const response = await fetch(path, {
       credentials: 'same-origin',
       headers: {
-        'Authorization': 'Bearer ' + token,
-        'content-type': 'application/jwt',
+        Authorization: 'Bearer ' + token,
       },
     });
     if (!response.ok) {

--- a/@uportal/content-carousel/src/lib/AuthenticatedRssStrategy.ts
+++ b/@uportal/content-carousel/src/lib/AuthenticatedRssStrategy.ts
@@ -1,0 +1,59 @@
+import {CarouselItem} from '@/lib/CarouselItem';
+import {DataStrategy} from '@/lib/DataStrategy';
+import {parseXml} from '@/lib/parse';
+import oidc from '@uportal/open-id-connect';
+
+export class AuthenticatedRssStrategy implements DataStrategy {
+  public readonly type = 'Authenticated RSS';
+
+  public items: CarouselItem[] = [];
+
+  constructor(public feed: string) {
+    this.load(feed);
+  }
+
+  private async load(path: string): Promise<any> {
+    const token = (await oidc()).encoded;
+    const response = await fetch(path, {
+      credentials: 'same-origin',
+      headers: {
+        'Authorization': 'Bearer ' + token,
+        'content-type': 'application/jwt',
+      },
+    });
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+    const feed = await response.text();
+
+    const {items} = await parseXml(feed);
+    this.items = items.map(
+        (
+            {
+              title,
+              description,
+              link,
+              media,
+              enclosures,
+            }: {
+            title: string;
+            description: string;
+            link: string;
+            media: any;
+            enclosures: any;
+            },
+            index: number,
+        ) => {
+          const image = media ? media.content : enclosures ? enclosures[0] : null;
+          return {
+            id: `${index}-${new Date().getTime()}`,
+            altText: `${title} - ${description}`,
+            destinationUrl: link,
+            imageUrl: image,
+            title,
+            description: image ? null : description,
+          };
+        },
+    );
+  }
+}


### PR DESCRIPTION
This is an attempt at providing an authenticated RSS strategy as described in #170. If there's a cleaner way to implement this, please advise.

closes #170