### PR TITLE
fix: fixed issue where empty slots were still displayed

### DIFF
--- a/@uportal/user-profile-menu/src/components/ProfileMenu.vue
+++ b/@uportal/user-profile-menu/src/components/ProfileMenu.vue
@@ -172,6 +172,9 @@ export default {
   }
 
   .profile-dropdown-section {
+    &:empty {
+      display: none;
+    }
     &.profile-dropdown-footer,
     &.profile-dropdown-header {
       padding: 1em;

--- a/@uportal/user-profile-menu/src/components/ProfileMenu.vue
+++ b/@uportal/user-profile-menu/src/components/ProfileMenu.vue
@@ -175,6 +175,7 @@ export default {
     &:empty {
       display: none;
     }
+
     &.profile-dropdown-footer,
     &.profile-dropdown-header {
       padding: 1em;


### PR DESCRIPTION
Fixed widget so that if a slot is empty (using :empty css selector), it does not get displayed.