### PR TITLE
fix: fixed size of dashboard content items & css variables for buttons

### DIFF
--- a/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
+++ b/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
@@ -191,6 +191,7 @@ export default {
     margin: 0 10px;
     padding: 10px;
     border: 1px solid #ccc;
+    max-width: 33%;
   }
 }
 
@@ -256,16 +257,24 @@ ul {
   border: #007bff;
   border: 1px solid var(--dash-carousel-btn-bg-color, #007bff);
   padding: 0.375rem 0.75rem;
+  padding: var(--dash-carousel-btn-padding, 0.375rem 0.75rem);
   font-size: 1rem;
+  font-size: var(--dash-carousel-btn-font-size, 1rem);
   line-height: 1.5;
   border-radius: 0.25rem;
   width: 100%;
 
   &:hover {
     background-color: #fff;
-    background-color: var(--dash-carousel-btn-bg-hover-color, var(--dash-carousel-btn-bg-active-color, #fff));
+    background-color: var(
+      --dash-carousel-btn-bg-hover-color,
+      var(--dash-carousel-btn-bg-active-color, #fff)
+    );
     color: #000;
-    color: var(--dash-carousel-btn-fg-hover-color, var(--dash-carousel-btn-fg-active-color, #000));
+    color: var(
+      --dash-carousel-btn-fg-hover-color,
+      var(--dash-carousel-btn-fg-active-color, #000)
+    );
   }
 
   &.active {
@@ -280,6 +289,9 @@ ul {
 @media (max-width: 767.98px) {
   .slick-item {
     flex-direction: column;
+    & > span {
+      max-width: none;
+    }
   }
 
   ul {

--- a/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
+++ b/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
@@ -289,6 +289,7 @@ ul {
 @media (max-width: 767.98px) {
   .slick-item {
     flex-direction: column;
+
     & > span {
       max-width: none;
     }

--- a/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
+++ b/@uportal/dashboard-carousel/src/components/DashboardCarousel.vue
@@ -266,11 +266,13 @@ ul {
 
   &:hover {
     background-color: #fff;
+    /* stylelint-disable-next-line declaration-colon-newline-after */
     background-color: var(
       --dash-carousel-btn-bg-hover-color,
       var(--dash-carousel-btn-bg-active-color, #fff)
     );
     color: #000;
+    /* stylelint-disable-next-line declaration-colon-newline-after */
     color: var(
       --dash-carousel-btn-fg-hover-color,
       var(--dash-carousel-btn-fg-active-color, #000)


### PR DESCRIPTION
Set max-width of content items for dashboard-carousel widget to 33% to avoid odd sizing issues.

Added CSS variables for sizing dashboard-carousel buttons (font/padding size).