### PR TITLE
fix: use wrong param AlternativeMaximizedLink + improvements

### DIFF
--- a/@uportal/waffle-menu/README.md
+++ b/@uportal/waffle-menu/README.md
@@ -109,6 +109,17 @@ Example:
 ></waffle-menu>
 ```
 
+### `context-portlet-url`
+
+Common URI or URL path to target a portlet inside the portal, the fname will be appended. The default value is
+`/uPortal/p/`.
+
+Example:
+
+```html
+<waffle-menu context-portlet-url="/portal/p/"></waffle-menu>
+```
+
 ### `debug`
 
 Disable open id connect for testing.

--- a/@uportal/waffle-menu/src/components/WaffleMenu.vue
+++ b/@uportal/waffle-menu/src/components/WaffleMenu.vue
@@ -149,7 +149,7 @@ export default {
 
             const alternativeMaximizedLink = get(
                 parameters,
-                'alternativeMaximized.value'
+                'alternativeMaximizedLink.value'
             );
 
             return {

--- a/@uportal/waffle-menu/src/components/WaffleMenu.vue
+++ b/@uportal/waffle-menu/src/components/WaffleMenu.vue
@@ -86,6 +86,10 @@ export default {
       type: String,
       default: '/uPortal/api/v5-1/userinfo',
     },
+    contextPortletUrl: {
+      type: String,
+      default: '/uPortal/p/',
+    },
     buttonColor: {
       type: String,
       default: '#fff',
@@ -164,7 +168,7 @@ export default {
             }
 
             return {
-              link: alternativeMaximizedLink || '/uPortal/p/' + fname,
+              link: alternativeMaximizedLink || this.contextPortletUrl + fname,
               image: imgUrl
               ? process.env.NODE_ENV === 'development'
                 ? 'proxy/' + imgUrl

--- a/@uportal/waffle-menu/src/components/WaffleMenu.vue
+++ b/@uportal/waffle-menu/src/components/WaffleMenu.vue
@@ -36,6 +36,8 @@
         <a
           :href="item.link"
           :background="item.image"
+          :target="item.targetLink"
+          :rel="item.targetLink === '_blank' ? 'noopener noreferrer' : ''"
         >
           <img
             :src="item.image"
@@ -48,7 +50,11 @@
         v-for="(item, index) in this.dataMenuFooter"
         :key="index"
       >
-        <a :href="item.link">
+        <a
+          :href="item.link"
+          :target="item.targetLink"
+          :rel="item.targetLink === '_blank' ? 'noopener noreferrer' : ''"
+        >
           {{ item.label }}
         </a>
       </li>
@@ -152,6 +158,11 @@ export default {
                 'alternativeMaximizedLink.value'
             );
 
+            let targetLinkValue = '_self';
+            if (alternativeMaximizedLink) {
+              targetLinkValue = '_blank';
+            }
+
             return {
               link: alternativeMaximizedLink || '/uPortal/p/' + fname,
               image: imgUrl
@@ -161,6 +172,7 @@ export default {
               : undefined,
               label: this.truncateTitle(title),
               type: 'box',
+              targetLink: targetLinkValue,
             };
           }
       );

--- a/docs/en/components/waffle-menu/README.md
+++ b/docs/en/components/waffle-menu/README.md
@@ -1,7 +1,7 @@
 # Waffle Menu
 
 [![NPM Version](https://img.shields.io/npm/v/@uportal/waffle-menu.svg)](https://www.npmjs.com/package/@uportal/waffle-menu)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.webjars.npm/waffle-menu/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.webjars.npm/uportal__waffle-menu)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.webjars.npm/uportal__waffle-menu/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.webjars.npm/uportal__waffle-menu)
 [![Build Status](https://travis-ci.org/uPortal-contrib/uPortal-web-components.svg?branch=master)](https://travis-ci.org/uPortal-contrib/uPortal-web-components)
 
 ## Demo
@@ -88,6 +88,15 @@ Example:
 
 `<waffle-menu button-color="#ffffff">`
 
+### `menu-background-color`
+
+applies a color to the waffle menu dropdown. Useful if you want to avoid specifying the color in CSS.
+If not set, `menu-background-color` defaults to `#e0e0e0`.
+
+Example:
+
+`<waffle-menu menu-background-color="#99aa99">`
+
 ### `url`
 
 Fully qualified url pointing to the API where `<waffle-menu>` can find data in portlet registry format.
@@ -98,6 +107,17 @@ Example:
 <waffle-menu
   url="/uPortal/api/v4-3/dlm/portletRegistry.json?categoryId=local.21"
 ></waffle-menu>
+```
+
+### `context-portlet-url`
+
+Common URI or URL path to target a portlet inside the portal, the fname will be appended. The default value is
+`/uPortal/p/`.
+
+Example:
+
+```html
+<waffle-menu context-portlet-url="/portal/p/"></waffle-menu>
 ```
 
 ### `debug`


### PR DESCRIPTION
This had some fix with the use of the AlternativeMaximizedLink and add a property to be able to customize the uPortal contact URL on portlet url.