### PR TITLE
chore: update 'build' script and 'source' setting to match other modules

### DIFF
--- a/@uportal/waffle-menu/package.json
+++ b/@uportal/waffle-menu/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "main": "dist/waffle-menu.js",
-  "source": "src/waffle-menu.js",
+  "source": "src/components/WaffleMenu.vue",
   "dependencies": {
     "@uportal/open-id-connect": "^1.26.1",
     "@uportal/portlet-registry-to-array": "^1.26.1",
@@ -30,7 +30,7 @@
   "scripts": {
     "start": "vue-cli-service serve",
     "prebuild": "babel node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js -o node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js",
-    "build": "vue-cli-service build --name waffle-menu --target wc src/components/WaffleMenu.vue"
+    "build": "vue-cli-service build --name waffle-menu --target wc 'src/components/*.vue'"
   },
   "bugs": {
     "url": "https://github.com/uPortal-contrib/uPortal-web-components/issues"


### PR DESCRIPTION
I hope that these changes will clear up the issues I'm having when I publish the `waffle-menu` webjar.