### PR TITLE
providing some improvements on esco-content-menu

### DIFF
--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -182,6 +182,26 @@ and with additional properties to work with the `hamburger-menu`:
 - `is-hidden`: type: `Boolean`, default: `false`, used by the `hamburger-menu` to indicate the state of the page.
 - `id`: type: `String`, default: `null`, provide an id to be able to select the dome element, as example if you want to manage manualy an `hamburger-menu`
 
+#### Slots
+
+The HTML content of the component can also be modified using [slots](https://vuejs.org/v2/guide/components-slots.html).
+
+##### Content User
+
+The `content-user` slot permit to apply a custom component at this place, or to remove it. As example:
+
+```html
+<esco-content-menu
+  sign-out-url="/uPortal/Logout"
+  default-org-logo="https://www.toureiffel.paris/sites/default/files/styles/1440x810/public/2017-10/monument-landing-header-bg_0.jpg?itok=_dSLLBlZ"
+  favorites-portlet-card-size="small"
+  grid-portlet-card-size="auto"
+  hide-action-mode="never"
+>
+  <div slot="content-user" />
+</esco-content-menu>
+```
+
 ### The content grid
 
 This component provide a flexbox way to show a list of `portlet-card`, depending on uPortal rest-api.

--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -217,6 +217,7 @@ Standalone properties:
 - `hide-action: type`: `Boolean`, default: `false`, define to hide or not the `action-favorite` button defined into `portlet-card`
 - `show-footer-categories`: `Boolean`, default: `false`, define to display category dropdown filter near bottom of grid
 - `hide-title`: `Boolean`, default: `false`, define to remove the title area from the grid, useful when a basic grid is desired
+- `portlet-background-is-dark`: `Boolean`, default: `false`, indicate to the component that the parent background is dark and permit to the portlet-card component to show buttons like favorites in a more suitable color.
 - `debug`: type: `Boolean`, default: `false`, for the demo/debug mode to be able to run in a standalone way (disable api call)
 
 and additional properties to work with the parent component `content-menu`:

--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -198,7 +198,7 @@ The `content-user` slot permit to apply a custom component at this place, or to 
   grid-portlet-card-size="auto"
   hide-action-mode="never"
 >
-  <div slot="content-user" />
+  <div slot="content-user"></div>
 </esco-content-menu>
 ```
 
@@ -214,7 +214,7 @@ The `header-buttons` slot permit to apply a custom component at this place, or t
   grid-portlet-card-size="auto"
   hide-action-mode="never"
 >
-  <div slot="header-buttons" />
+  <div slot="header-buttons"></div>
 </esco-content-menu>
 ```
 

--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -202,6 +202,22 @@ The `content-user` slot permit to apply a custom component at this place, or to 
 </esco-content-menu>
 ```
 
+##### Header Buttons
+
+The `header-buttons` slot permit to apply a custom component at this place, or to remove it. As example:
+
+```html
+<esco-content-menu
+  sign-out-url="/uPortal/Logout"
+  default-org-logo="https://www.toureiffel.paris/sites/default/files/styles/1440x810/public/2017-10/monument-landing-header-bg_0.jpg?itok=_dSLLBlZ"
+  favorites-portlet-card-size="small"
+  grid-portlet-card-size="auto"
+  hide-action-mode="never"
+>
+  <div slot="header-buttons" />
+</esco-content-menu>
+```
+
 ### The content grid
 
 This component provide a flexbox way to show a list of `portlet-card`, depending on uPortal rest-api.

--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -275,6 +275,17 @@ The `footer` slot permit to apply a custom title replacing the default filter on
 </content-grid>
 ```
 
+#### Theming
+
+This component supports [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables) for overriding some default values. So defining the following variables will override default values.
+
+```css
+:root {
+  --content-grid-flex-grid-justify: center; // How to justify all flex grid elements, default value is center
+  --content-grid-flex-grid-item-margin: 20px auto; // To set a margin on all flex items, default is `20px auto`
+}
+```
+
 ### The action favorite
 
 The component `action-favorite` is really simple, it show a start button that permit to add or remove from favorites a portlet.

--- a/@uportal/esco-content-menu/public/index.html
+++ b/@uportal/esco-content-menu/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/@uportal/esco-content-menu/src/App.vue
+++ b/@uportal/esco-content-menu/src/App.vue
@@ -1,8 +1,7 @@
 <template>
   <div id="app">
-    <hamburger-menu
+    <!-- <hamburger-menu
       default-org-logo="https://lycees.netocentre.fr/annuaire_images/default_banner_v1.jpg"
-      api-url-org-info="/p/test"
       favorites-portlet-card-size="small"
       grid-portlet-card-size="auto"
       hide-action-mode="never"
@@ -10,27 +9,40 @@
       layout-api-url="layout.json"
       organization-api-url="orginfo.json"
       user-info-api-url="userinfo.json"
-      debug/>
-      <!-- <content-grid
+      debug /> -->
+    <!-- <content-grid
       background-color="grey"
       portlet-card-size="medium"
       portlet-api-url="portletRegistry.json"
       layout-api-url="layout.json"
       debug /> -->
+    <content-menu
+      default-org-logo="https://lycees.netocentre.fr/annuaire_images/default_banner_v1.jpg"
+      favorites-portlet-card-size="small"
+      grid-portlet-card-size="auto"
+      hide-action-mode="never"
+      portlet-api-url="portletRegistry.json"
+      layout-api-url="layout.json"
+      organization-api-url="orginfo.json"
+      user-info-api-url="userinfo.json"
+      :show-favorites-in-slider="false"
+      debug>
+      <!--      <div slot="content-user"></div>-->
+    </content-menu>
   </div>
 </template>
 
 <script>
-// import ContentMenu from './components/ContentMenu.vue';
+import ContentMenu from './components/ContentMenu.vue';
 // import ContentGrid from './components/ContentGrid.vue';
-import HamburgerMenu from './components/HamburgerMenu';
+// import HamburgerMenu from './components/HamburgerMenu';
 
 export default {
   name: 'App',
   components: {
-    // ContentMenu,
+    ContentMenu,
     // ContentGrid,
-    HamburgerMenu,
+    // HamburgerMenu,
   },
 };
 </script>

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -50,6 +50,7 @@
         <div
           v-for="portlet in filteredPortlets"
           :key="portlet.id"
+          :class="['portlet-card-' + _portletCardSize]"
           class="flex-item ma-3 text-xs-center">
           <a
             :href="getRenderPortletUrl(portlet)"
@@ -470,7 +471,7 @@ $searchSize: 32px;
     .flex-grid {
       display: flex;
       flex-flow: row wrap;
-      justify-content: center;
+      justify-content: var(--content-grid-flex-grid-justify, center);
 
       .flex-item {
         margin: 20px auto;

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -66,6 +66,7 @@
               :call-after-action="actionToggleFav"
               :favorite-api-url="favoriteApiUrl"
               :user-info-api-url="userInfoApiUrl"
+              :back-ground-is-dark="portletBackgroundIsDark"
               :debug="debug"/>
           </a>
         </div>
@@ -168,6 +169,7 @@ export default {
      */
     portlets: {type: Array, default: undefined},
     showFooterCategories: {type: Boolean, default: false},
+    portletBackgroundIsDark: {type: Boolean, default: false},
   },
   data() {
     return {

--- a/@uportal/esco-content-menu/src/components/ContentMenu.vue
+++ b/@uportal/esco-content-menu/src/components/ContentMenu.vue
@@ -7,15 +7,17 @@
         :call-on-close="close"
         :sign-out-url="signOutUrl" />
       <div class="wrapper">
-        <content-user
-          :org-info="_userOrganization"
-          :user-info="_user"
-          :other-orgs="_organizations"
-          :parent-screen-size="_screenSize"
-          :default-org-logo="defaultOrgLogo"
-          :user-info-portlet-url="userInfoPortletUrl"
-          :switch-org-portlet-url="switchOrgPortletUrl"
-          :org-logo-url-attribute-name="orgLogoUrlAttributeName"/>
+        <slot name="content-user">
+          <content-user
+            :org-info="_userOrganization"
+            :user-info="_user"
+            :other-orgs="_organizations"
+            :parent-screen-size="_screenSize"
+            :default-org-logo="defaultOrgLogo"
+            :user-info-portlet-url="userInfoPortletUrl"
+            :switch-org-portlet-url="switchOrgPortletUrl"
+            :org-logo-url-attribute-name="orgLogoUrlAttributeName"/>
+        </slot>
         <content-favorites
           :portlets="_portlets"
           :favorites="_favorites"

--- a/@uportal/esco-content-menu/src/components/ContentMenu.vue
+++ b/@uportal/esco-content-menu/src/components/ContentMenu.vue
@@ -3,9 +3,11 @@
     :class="['toggler-menu', _screenSize, !_isHidden ? 'active-menu' : '']"
     class="content-menu">
     <header>
-      <header-buttons
-        :call-on-close="close"
-        :sign-out-url="signOutUrl" />
+      <slot name="header-buttons">
+        <header-buttons
+          :call-on-close="close"
+          :sign-out-url="signOutUrl" />
+      </slot>
       <div class="wrapper">
         <slot name="content-user">
           <content-user

--- a/@uportal/esco-content-menu/src/components/ContentMenu.vue
+++ b/@uportal/esco-content-menu/src/components/ContentMenu.vue
@@ -29,7 +29,8 @@
           :is-hidden="_isHidden"
           :user-info-api-url="userInfoApiUrl"
           :context-api-url="contextApiUrl"
-          :debug="debug"/>
+          :debug="debug"
+          :use-swipper="showFavoritesInSlider"/>
       </div>
       <div
         :style="
@@ -152,6 +153,7 @@ export default {
       type: String,
       default: 'otherAttributes.ESCOStructureLogo[0]',
     },
+    showFavoritesInSlider: {type: Boolean, default: true},
   },
   data() {
     return {

--- a/@uportal/esco-content-menu/src/components/ContentUser.vue
+++ b/@uportal/esco-content-menu/src/components/ContentUser.vue
@@ -159,6 +159,7 @@ export default {
       align-items: center;
       justify-content: center;
       flex: 1;
+      margin-top: 15px;
 
       img {
         width: 270px;

--- a/@uportal/esco-content-menu/src/components/ContentUser.vue
+++ b/@uportal/esco-content-menu/src/components/ContentUser.vue
@@ -152,12 +152,13 @@ export default {
     display: flex;
     flex-direction: column;
     height: 100%;
+    justify-content: flex-end;
 
     > .org-img {
       display: flex;
       align-items: center;
       justify-content: center;
-      margin-top: auto;
+      flex: 1;
 
       img {
         width: 270px;
@@ -231,10 +232,6 @@ export default {
           }
         }
       }
-    }
-
-    > .org-img + .user-info {
-      margin-top: auto;
     }
   }
 }

--- a/@uportal/esco-content-menu/src/components/HamburgerMenu.vue
+++ b/@uportal/esco-content-menu/src/components/HamburgerMenu.vue
@@ -40,6 +40,7 @@
         :user-org-id-attribute-name="userOrgIdAttributeName"
         :user-all-orgs-id-attribute-name="userAllOrgsIdAttributeName"
         :org-logo-url-attribute-name="orgLogoUrlAttributeName"
+        :show-favorites-in-slider="showFavoritesInSlider"
         default-class="toggler-menu"
         visible-class="active-menu"/>
     </slot>
@@ -109,6 +110,7 @@ export default {
       type: String,
       default: 'otherAttributes.ESCOStructureLogo[0]',
     },
+    showFavoritesInSlider: {type: Boolean, default: true},
   },
   data() {
     return {

--- a/@uportal/esco-content-menu/src/locales/en-US.json
+++ b/@uportal/esco-content-menu/src/locales/en-US.json
@@ -1,0 +1,27 @@
+{
+  "message": {
+    "services": {
+      "title": "All services",
+      "filter": "Find a service..."
+    },
+    "favorites": {
+      "add": "Add to favorites",
+      "remove": "Remove from favorites",
+      "title": "My Favorites",
+      "empty": "No favorite defined"
+    },
+    "filter": {
+      "selectOption": "All categories"
+    },
+    "userInfoPortletUrl": {
+      "title": "See my account informations"
+    },
+    "userChangeEtabUrl": {
+      "title": "Select an other organization"
+    },
+    "buttons": {
+      "logout": "Sign out",
+      "menuClose": "Close menu"
+    }
+  }
+}

--- a/@uportal/esco-content-menu/src/locales/fr-FR.json
+++ b/@uportal/esco-content-menu/src/locales/fr-FR.json
@@ -1,0 +1,27 @@
+{
+  "message": {
+    "services": {
+      "title": "Tous les services",
+      "filter": "Rechercher un service..."
+    },
+    "favorites": {
+      "add": "Ajouter aux favoris",
+      "remove": "Supprimer des favoris",
+      "title": "Mes favoris",
+      "empty": "Aucun favori défini"
+    },
+    "filter": {
+      "selectOption": "Toutes les catégories"
+    },
+    "userInfoPortletUrl": {
+      "title": "Voir les informations de mon compte"
+    },
+    "userChangeEtabUrl": {
+      "title": "Changer d'établissement"
+    },
+    "buttons": {
+      "logout": "Déconnexion",
+      "menuClose": "Fermer le menu"
+    }
+  }
+}

--- a/docs/en/components/esco-content-menu/README.md
+++ b/docs/en/components/esco-content-menu/README.md
@@ -182,6 +182,26 @@ and with additional properties to work with the `hamburger-menu`:
 - `is-hidden`: type: `Boolean`, default: `false`, used by the `hamburger-menu` to indicate the state of the page.
 - `id`: type: `String`, default: `null`, provide an id to be able to select the dome element, as example if you want to manage manualy an `hamburger-menu`
 
+#### Slots
+
+The HTML content of the component can also be modified using [slots](https://vuejs.org/v2/guide/components-slots.html).
+
+##### Content User
+
+The `content-user` slot permit to apply a custom component at this place, or to remove it. As example:
+
+```html
+<esco-content-menu
+  sign-out-url="/uPortal/Logout"
+  default-org-logo="https://www.toureiffel.paris/sites/default/files/styles/1440x810/public/2017-10/monument-landing-header-bg_0.jpg?itok=_dSLLBlZ"
+  favorites-portlet-card-size="small"
+  grid-portlet-card-size="auto"
+  hide-action-mode="never"
+>
+  <div slot="content-user" />
+</esco-content-menu>
+```
+
 ### The content grid
 
 This component provide a flexbox way to show a list of `portlet-card`, depending on uPortal rest-api.

--- a/docs/en/components/esco-content-menu/README.md
+++ b/docs/en/components/esco-content-menu/README.md
@@ -217,6 +217,7 @@ Standalone properties:
 - `hide-action: type`: `Boolean`, default: `false`, define to hide or not the `action-favorite` button defined into `portlet-card`
 - `show-footer-categories`: `Boolean`, default: `false`, define to display category dropdown filter near bottom of grid
 - `hide-title`: `Boolean`, default: `false`, define to remove the title area from the grid, useful when a basic grid is desired
+- `portlet-background-is-dark`: `Boolean`, default: `false`, indicate to the component that the parent background is dark and permit to the portlet-card component to show buttons like favorites in a more suitable color.
 - `debug`: type: `Boolean`, default: `false`, for the demo/debug mode to be able to run in a standalone way (disable api call)
 
 and additional properties to work with the parent component `content-menu`:

--- a/docs/en/components/esco-content-menu/README.md
+++ b/docs/en/components/esco-content-menu/README.md
@@ -198,7 +198,7 @@ The `content-user` slot permit to apply a custom component at this place, or to 
   grid-portlet-card-size="auto"
   hide-action-mode="never"
 >
-  <div slot="content-user" />
+  <div slot="content-user"></div>
 </esco-content-menu>
 ```
 
@@ -214,7 +214,7 @@ The `header-buttons` slot permit to apply a custom component at this place, or t
   grid-portlet-card-size="auto"
   hide-action-mode="never"
 >
-  <div slot="header-buttons" />
+  <div slot="header-buttons"></div>
 </esco-content-menu>
 ```
 

--- a/docs/en/components/esco-content-menu/README.md
+++ b/docs/en/components/esco-content-menu/README.md
@@ -202,6 +202,22 @@ The `content-user` slot permit to apply a custom component at this place, or to 
 </esco-content-menu>
 ```
 
+##### Header Buttons
+
+The `header-buttons` slot permit to apply a custom component at this place, or to remove it. As example:
+
+```html
+<esco-content-menu
+  sign-out-url="/uPortal/Logout"
+  default-org-logo="https://www.toureiffel.paris/sites/default/files/styles/1440x810/public/2017-10/monument-landing-header-bg_0.jpg?itok=_dSLLBlZ"
+  favorites-portlet-card-size="small"
+  grid-portlet-card-size="auto"
+  hide-action-mode="never"
+>
+  <div slot="header-buttons" />
+</esco-content-menu>
+```
+
 ### The content grid
 
 This component provide a flexbox way to show a list of `portlet-card`, depending on uPortal rest-api.

--- a/docs/en/components/esco-content-menu/README.md
+++ b/docs/en/components/esco-content-menu/README.md
@@ -275,6 +275,17 @@ The `footer` slot permit to apply a custom title replacing the default filter on
 </content-grid>
 ```
 
+#### Theming
+
+This component supports [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables) for overriding some default values. So defining the following variables will override default values.
+
+```css
+:root {
+  --content-grid-flex-grid-justify: center; // How to justify all flex grid elements, default value is center
+  --content-grid-flex-grid-item-margin: 20px auto; // To set a margin on all flex items, default is `20px auto`
+}
+```
+
 ### The action favorite
 
 The component `action-favorite` is really simple, it show a start button that permit to add or remove from favorites a portlet.


### PR DESCRIPTION
This provide some improvments :
- the possibility to set css variable on the content-grid
- the possibility to remove the content-user from the esco-content-menu via slot
- the possibility to remove the header-buttons from esco-content-menu via slot
- the possibility to switch from a slider to the content-grid for the favorite part into esco-content-menu, and from the esco-hamburger-menu
- fix language detection, based on main document lang property (this permit to be based on the uPortal lang definition).

