### PR TITLE
feat: custom content card size

### DIFF
--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -81,8 +81,8 @@ For some integration you could need a bit more, like into uPortal you will need 
 - `default-org-logo`: type: `String`, required: true, an url/uri to provide an institutional picture when none is found from an optional api (not provided into uPortal),
 - `user-info-portlet-url`: type: `String`, default: `''`, an url/uri to the user information application,
 - `switch-org-portlet-url`: type: `String`, default: `''`, an optional url/url of a rest api to obtain institutional organization information,
-- `favorites-portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of portlet-cards component into `favorite-content` component part,
-- `grid-portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of `portlet-cards` component into `grid-content` component part,
+- `favorites-portlet-card-size`: type: possible value `auto|large|medium|small|smaller|custom`, default: `auto`, define the size of portlet-cards component into `favorite-content` component part,
+- `grid-portlet-card-size`: type: possible value `auto|large|medium|small|smaller|custom`, default: `auto`, define the size of `portlet-cards` component into `grid-content` component part,
 - `hide-action-mode: type`: possible value `auto|always|never`, default: `auto`, define if we should show the actions, `auto` don't show on `small` breakpoint,
 - `user-org-id-attribute-name`: type: `String`, default: `'ESCOSIRENCourant[0]'`, the attribute object path to obtain the id of the organization to retrieve from the organization's api
 - `user-all-orgs-id-attribute-name`: type: `String`, default: `'ESCOSIREN`, the attribute object path to obtain all ids of the organizations linked to the user and to retrieve from the organization's api
@@ -213,7 +213,7 @@ Standalone properties:
 - `layout-api-url`: type: `String`, default: `/uPortal/api/v4-3/dlm/layout.json`, the uri/url of the layout api to request the favorite list in the other defined order (only needed to get favorite's order defined by the user)
 - `portlet-api-url`: type: `String`, default: `/uPortal/api/v4-3/dlm/portletRegistry.json`, the uri/url of the portletRegistry api to obtains user authorized portlet list
 - `userInfo-api-url`: type: `String`, default: `/uPortal/api/v5-1/userinfo`, url/uri on which the api request is done to obtain user information and the jwt token
-- `portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of `portlet-cards` component.
+- `portlet-card-size`: type: possible value `auto|large|medium|small|smaller|custom`, default: `auto`, define the size of `portlet-cards` component.
 - `hide-action: type`: `Boolean`, default: `false`, define to hide or not the `action-favorite` button defined into `portlet-card`
 - `show-footer-categories`: `Boolean`, default: `false`, define to display category dropdown filter near bottom of grid
 - `hide-title`: `Boolean`, default: `false`, define to remove the title area from the grid, useful when a basic grid is desired
@@ -221,7 +221,7 @@ Standalone properties:
 
 and additional properties to work with the parent component `content-menu`:
 
-- `parent-screen-size`: type: possible value `large|medium|small|smaller`, default: `medium`, permit to indicate the breakpoint view of the parent.
+- `parent-screen-size`: type: possible value `large|medium|small|smaller|custom`, default: `medium`, permit to indicate the breakpoint view of the parent.
 - `portlets`: type: `Array`, default: `undefined`, used if the list of portlets is loaded and provided from a parent component,
 - `favorites`: type: `Array`, default: `undefined`, used if the list of favorites portlets loaded and provided from a parent component,
 
@@ -352,7 +352,7 @@ This component render informations about a portlet as a card.
 #### Properties
 
 - `portlet-desc`: type: `Object`, required: `true`, the portlet description object
-- `size`: type: possible value `large|medium|small|smaller`, default: `medium`, the fixed size of card to apply
+- `size`: type: possible value `large|medium|small|smaller|custom`, default: `medium`, the fixed size of card to apply
 - `hide-action: type`: `Boolean`, default: `false`, define to hide or not the `action-favorite` button
 - `back-ground-is-dark`: type: `Boolean`, default: `false`, permit to apply a style depending on background color, as the component is used as embeded,
 - `is-favorite`: type: `Boolean`, default: `false`, provide the favorite state (passed to the `action-favorite` component),
@@ -436,3 +436,30 @@ This component render a header part with some main buttons, like closing the pag
 
 - Q: What does "ESCO" mean?
 - A: "ESCO" is an abbreviation of "e-scolaire", French for Online School.
+
+### Theming
+
+Currently this component supports [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables) for overriding button colors. Defining the following variables will change the colors for the component accordingly. They will fall back to the colors described below.
+
+**_NOTE:_** This is only supported when the size attribute is set to `custom`.
+
+You should define this in your custom stylesheet.
+
+```css
+:root {
+  --content-gridcard-padding: 5px;
+  --content-gridcard-border: none;
+  --content-gridcard-bg-color: white;
+  --content-gridcard-border-radius: 5px;
+  --content-gridcard-shadow: none;
+  --content-gridcard-shadow-hover: none;
+  --content-gridcard-size-w: 180px;
+  --content-gridcard-size-h: 180px;
+  --content-gridcard-icon-size: 75px;
+  --content-gridcard-icon-size: 75px;
+  --content-gridcard-title-fontsize: 16px;
+  --content-gridcard-description-fontsize: 16px;
+
+  --content-griditem-margin: 20px auto;
+}
+```

--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -81,8 +81,8 @@ For some integration you could need a bit more, like into uPortal you will need 
 - `default-org-logo`: type: `String`, required: true, an url/uri to provide an institutional picture when none is found from an optional api (not provided into uPortal),
 - `user-info-portlet-url`: type: `String`, default: `''`, an url/uri to the user information application,
 - `switch-org-portlet-url`: type: `String`, default: `''`, an optional url/url of a rest api to obtain institutional organization information,
-- `favorites-portlet-card-size`: type: possible value `auto|large|medium|small|smaller|custom`, default: `auto`, define the size of portlet-cards component into `favorite-content` component part,
-- `grid-portlet-card-size`: type: possible value `auto|large|medium|small|smaller|custom`, default: `auto`, define the size of `portlet-cards` component into `grid-content` component part,
+- `favorites-portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of portlet-cards component into `favorite-content` component part,
+- `grid-portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of `portlet-cards` component into `grid-content` component part,
 - `hide-action-mode: type`: possible value `auto|always|never`, default: `auto`, define if we should show the actions, `auto` don't show on `small` breakpoint,
 - `user-org-id-attribute-name`: type: `String`, default: `'ESCOSIRENCourant[0]'`, the attribute object path to obtain the id of the organization to retrieve from the organization's api
 - `user-all-orgs-id-attribute-name`: type: `String`, default: `'ESCOSIREN`, the attribute object path to obtain all ids of the organizations linked to the user and to retrieve from the organization's api

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -472,6 +472,7 @@ $searchSize: 32px;
 
       .flex-item {
         margin: 20px auto;
+        margin: var(--content-griditem-margin);
         padding: 0 2.5px;
       }
 

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -159,7 +159,7 @@ export default {
       default: 'medium',
     },
     portletCardSize: {
-      validator: (value) => sizeValidator(value, true),
+      validator: (value) => sizeValidator(value, true, true),
       default: 'auto',
     },
     hideAction: {type: Boolean, default: false},

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -472,7 +472,7 @@ $searchSize: 32px;
 
       .flex-item {
         margin: 20px auto;
-        margin: var(--content-griditem-margin);
+        margin: var(--content-griditem-margin, 20px auto);
         padding: 0 2.5px;
       }
 

--- a/@uportal/esco-content-menu/src/components/PortletCard.vue
+++ b/@uportal/esco-content-menu/src/components/PortletCard.vue
@@ -218,6 +218,51 @@ export default {
     font-size: 14px;
   }
 
+  &.custom-card {
+    padding: 5px;
+    padding: var(--content-gridcard-padding, 5px);
+    border: none;
+    border: var(--content-gridcard-border, none);
+    background-color: white;
+    background-color: var(--content-gridcard-bg-color, white);
+    border-radius: 5px;
+    border-radius: var(--content-gridcard-border-radius, 5px);
+    box-shadow: none;
+    box-shadow: var(--content-gridcard-shadow, none);
+    transition: box-shadow 0.25s;
+    width: $PortletCardSizeCustomWidth;
+    width: var(--content-gridcard-size-w, $PortletCardSizeCustomWidth);
+    height: $PortletCardSizeCustomHeight;
+    height: var(--content-gridcard-size-h, $PortletCardSizeCustomHeight);
+
+    &:hover {
+      cursor: pointer;
+      box-shadow: none;
+      box-shadow: var(--content-gridcard-shadow-hover, none);
+    }
+
+    & > .portlet-card-icon {
+      > div {
+        height: 75px;
+        height: var(--content-gridcard-icon-size, 75px);
+        width: 75px;
+        width: var(--content-gridcard-icon-size, 75px);
+        margin-top: 0px;
+      }
+    }
+
+    > .portlet-card-title {
+      overflow-x: hidden;
+      overflow-y: visible;
+      text-overflow: ellipsis;
+      font-size: var(--content-gridcard-title-fontsize, 16px);
+    }
+
+    > .portlet-card-description {
+      font-size: var(--content-gridcard-description-fontsize, 16px);
+    }
+  }
+
   &.medium-card,
   &.small-card,
   &.smaller-card {

--- a/@uportal/esco-content-menu/src/components/PortletCard.vue
+++ b/@uportal/esco-content-menu/src/components/PortletCard.vue
@@ -247,7 +247,7 @@ export default {
         height: var(--content-gridcard-icon-size, 75px);
         width: 75px;
         width: var(--content-gridcard-icon-size, 75px);
-        margin-top: 0px;
+        margin-top: 0;
       }
     }
 

--- a/@uportal/esco-content-menu/src/components/PortletCard.vue
+++ b/@uportal/esco-content-menu/src/components/PortletCard.vue
@@ -72,7 +72,7 @@ export default {
     },
     debug: {type: Boolean, default: false},
     size: {
-      validator: sizeValidator(),
+      validator: (value) => sizeValidator(value, true, true),
       default: 'medium',
     },
     hideAction: {type: Boolean, default: false},
@@ -236,7 +236,6 @@ export default {
     height: var(--content-gridcard-size-h, $PortletCardSizeCustomHeight);
 
     &:hover {
-      cursor: pointer;
       box-shadow: none;
       box-shadow: var(--content-gridcard-shadow-hover, none);
     }

--- a/@uportal/esco-content-menu/src/services/sizeTools.js
+++ b/@uportal/esco-content-menu/src/services/sizeTools.js
@@ -15,11 +15,13 @@ export function breakPointName(size) {
   return 'large';
 }
 
-export function sizeValidator(value, withAuto = false) {
+export function sizeValidator(value, withAuto = false, withCustom = false) {
+  let options = ['large', 'medium', 'small', 'smaller'];
   if (withAuto) {
-    return ['auto', 'large', 'medium', 'small', 'smaller', 'custom'].includes(
-        value
-    );
+    options = [...options, 'auto'];
   }
-  return ['large', 'medium', 'small', 'smaller', 'custom'].includes(value);
+  if (withCustom) {
+    options = [...options, 'custom'];
+  }
+  return options.includes(value);
 }

--- a/@uportal/esco-content-menu/src/services/sizeTools.js
+++ b/@uportal/esco-content-menu/src/services/sizeTools.js
@@ -17,7 +17,9 @@ export function breakPointName(size) {
 
 export function sizeValidator(value, withAuto = false) {
   if (withAuto) {
-    return ['auto', 'large', 'medium', 'small', 'smaller'].includes(value);
+    return ['auto', 'large', 'medium', 'small', 'smaller', 'custom'].includes(
+        value
+    );
   }
-  return ['large', 'medium', 'small', 'smaller'].includes(value);
+  return ['large', 'medium', 'small', 'smaller', 'custom'].includes(value);
 }

--- a/@uportal/esco-content-menu/src/styles/vars.scss
+++ b/@uportal/esco-content-menu/src/styles/vars.scss
@@ -3,3 +3,6 @@ $PortletCardSizeMedium: 205px;
 $PortletCardSizeSmall: 120px;
 $PortletCardSizeSmaller: 100px;
 $PortletCardButtonSize: 44px;
+
+$PortletCardSizeCustomWidth: 180px;
+$PortletCardSizeCustomHeight: 180px;


### PR DESCRIPTION
This adds a new option for the esco content grid to provide custom css variables to control various pieces of the grid's cards/items.