### PR TITLE
fix(content-grid): set matchSorter to ACRONYM

### DIFF
--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -218,6 +218,7 @@ export default {
             (portlets) =>
               matchSorter(portlets, this.filterValue, {
                 keys: ['title', 'name', 'description'],
+                threshold: matchSorter.rankings.ACRONYM,
               });
 
       return valueFilter(categoryFilter(portlets));


### PR DESCRIPTION
from the search term `adm` the default matcher make ranked search like a such request  `%a%d%m`, when moving to `ACRONYM` it will try to do it only on each first word letter.
Results are a bit more fined, and more understandable for users.