### PR TITLE
docs: update demo page dependencies

### DIFF
--- a/docs/en/components/content-carousel/demo.html
+++ b/docs/en/components/content-carousel/demo.html
@@ -35,11 +35,17 @@
       <div class="slick-item">slides</div>
     </content-carousel>
 
-    <script src="https://unpkg.com/vue"></script>
-    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.8"></script>
-    <script src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
-    <script src="https://unpkg.com/whatwg-fetch"></script>
-    <script src="https://unpkg.com/@webcomponents/webcomponentsjs"></script>
-    <script src="https://unpkg.com/@uportal/content-carousel"></script>
+    <script src="https://unpkg.com/vue" defer></script>
+    <script src="https://unpkg.com/core-js-bundle" defer></script>
+    <script
+      src="https://unpkg.com/regenerator-runtime/runtime.js"
+      defer
+    ></script>
+    <script src="https://unpkg.com/whatwg-fetch" defer></script>
+    <script
+      src="https://unpkg.com/@webcomponents/webcomponentsjs"
+      defer
+    ></script>
+    <script src="https://unpkg.com/@uportal/content-carousel" defer></script>
   </body>
 </html>

--- a/docs/en/components/dashboard-carousel/demo.html
+++ b/docs/en/components/dashboard-carousel/demo.html
@@ -8,11 +8,17 @@
     <dashboard-carousel debug layout-api-url="layout.json">
     </dashboard-carousel>
 
-    <script src="https://unpkg.com/vue"></script>
-    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.8"></script>
-    <script src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
-    <script src="https://unpkg.com/whatwg-fetch"></script>
-    <script src="https://unpkg.com/@webcomponents/webcomponentsjs"></script>
-    <script src="https://unpkg.com/@uportal/dashboard-carousel"></script>
+    <script src="https://unpkg.com/vue" defer></script>
+    <script src="https://unpkg.com/core-js-bundle" defer></script>
+    <script
+      src="https://unpkg.com/regenerator-runtime/runtime.js"
+      defer
+    ></script>
+    <script src="https://unpkg.com/whatwg-fetch" defer></script>
+    <script
+      src="https://unpkg.com/@webcomponents/webcomponentsjs"
+      defer
+    ></script>
+    <script src="https://unpkg.com/@uportal/dashboard-carousel" defer></script>
   </body>
 </html>

--- a/docs/en/components/esco-content-menu/demo.html
+++ b/docs/en/components/esco-content-menu/demo.html
@@ -74,12 +74,18 @@
       </esco-content-grid>
     </section>
     <footer></footer>
-    <script src="https://unpkg.com/vue"></script>
-    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.8"></script>
-    <script src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
-    <script src="https://unpkg.com/whatwg-fetch"></script>
-    <script src="https://unpkg.com/@webcomponents/webcomponentsjs"></script>
-    <script src="https://unpkg.com/@uportal/esco-content-menu"></script>
-    <script src="https://unpkg.com/@uportal/eyebrow-user-info"></script>
+    <script src="https://unpkg.com/vue" defer></script>
+    <script src="https://unpkg.com/core-js-bundle" defer></script>
+    <script
+      src="https://unpkg.com/regenerator-runtime/runtime.js"
+      defer
+    ></script>
+    <script src="https://unpkg.com/whatwg-fetch" defer></script>
+    <script
+      src="https://unpkg.com/@webcomponents/webcomponentsjs"
+      defer
+    ></script>
+    <script src="https://unpkg.com/@uportal/esco-content-menu" defer></script>
+    <script src="https://unpkg.com/@uportal/eyebrow-user-info" defer></script>
   </body>
 </html>

--- a/docs/en/components/waffle-menu/demo.html
+++ b/docs/en/components/waffle-menu/demo.html
@@ -70,10 +70,17 @@
       </nav>
     </header>
 
-    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.8"></script>
-    <script src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
-    <script src="https://unpkg.com/whatwg-fetch"></script>
-    <script src="https://unpkg.com/@webcomponents/webcomponentsjs"></script>
-    <script src="https://unpkg.com/@uportal/waffle-menu"></script>
+    <script src="https://unpkg.com/vue" defer></script>
+    <script src="https://unpkg.com/core-js-bundle" defer></script>
+    <script
+      src="https://unpkg.com/regenerator-runtime/runtime.js"
+      defer
+    ></script>
+    <script src="https://unpkg.com/whatwg-fetch" defer></script>
+    <script
+      src="https://unpkg.com/@webcomponents/webcomponentsjs"
+      defer
+    ></script>
+    <script src="https://unpkg.com/@uportal/waffle-menu" defer></script>
   </body>
 </html>


### PR DESCRIPTION
defer scripts.
use latest version of core js bundle.
include vue in waffle menu demo.