### PR TITLE
fix: avoid Favorites click propagation

### DIFF
--- a/@uportal/esco-content-menu/src/components/ActionFavorites.vue
+++ b/@uportal/esco-content-menu/src/components/ActionFavorites.vue
@@ -71,6 +71,7 @@ export default {
   methods: {
     toggleFavorite(event) {
       event.preventDefault();
+      event.stopPropagation();
       if (!this.debug) {
         if (this.favorite) {
           this.removeFromFavorite();


### PR DESCRIPTION
The onClick on the fav icon is propageted on parent elements whereas it's not required (even for the content-grid) as a callback function entry is provided to manage the action.
