### PR TITLE
docs: update committers

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,21 +1,23 @@
 # Project Lead and Committers
 
-# Project Lead
+## Project Lead
 
 Christian Murphy (@ChristianMurphy)
 
-# Committers
+## Committers
 
 The committers for this project are those for uPortal itself, documented as of this writing in [`COMMITTERS.md` in Jasig/uPortal](https://github.com/Jasig/uPortal/blob/master/docs/COMMITTERS.md).
 
 With the addition of the following committers:
 
-- Chris Beach (@cbeach47)
 - Chris Paraiso (@cparaiso)
-- Jeff Sittler (@mindblender)
 - Phillip Ball (@illiphilli)
 - Ryan Mathis (@rmathis)
 
 (Modeled as [a GitHub Team][uportal-web-components-committers] with `Admin` on the `uPortal-contrib/uPortal-web-components` repo.)
 
 [uportal-web-components-committers]: https://github.com/orgs/uPortal-contrib/teams/uportal-web-components-committers
+
+## Committers Emeriti
+
+- Jeff Sittler (@mindblender)


### PR DESCRIPTION
Chris Beach is now a uPortal committer, removing duplicated entry here.
Jeff is no longer an active committer to the project, moving him to Emeriti category