### PR TITLE
Waffle menu/accessibility enhancements

### DIFF
--- a/@uportal/waffle-menu/src/components/WaffleMenu.vue
+++ b/@uportal/waffle-menu/src/components/WaffleMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="waffle-menu-container" ref="waffleMenu">
-    <button class="waffle-trigger" @click="toggleMenu()">
+    <button class="waffle-trigger" @click="toggleMenu()" :aria-label="ariaLabel">
       <FontAwesomeIcon icon="th" :color="buttonColor" size="2x" />
       <div v-if="menuOpen">
         <div class="waffle-triangle-black" />
@@ -74,6 +74,10 @@ export default {
       type: String,
       default: '#fff'
     },
+    buttonLabel: {
+      type: String,
+      default: 'Waffle Menu',
+    },
     menuBackgroundColor: {
       type: String,
       default: '#fff'
@@ -104,6 +108,7 @@ export default {
   data() {
     return {
       menuOpen: false,
+      ariaLabel : this.buttonLabel + ' closed',
       data: [],
       dataItems: [],
       dataLoaded: false,
@@ -199,6 +204,7 @@ export default {
     // toggle the menu
     toggleMenu() {
       this.menuOpen = !this.menuOpen;
+      this.updateAriaLabel();
     },
     // close the menu if we're clicking outside the menu or trigger
     handleOutsideClick(event) {
@@ -215,6 +221,14 @@ export default {
         this.$refs.waffleMenu.querySelector('.waffle-trigger').focus();
       }
     },
+    updateAriaLabel() {
+      if (this.menuOpen) {
+        this.ariaLabel = this.buttonLabel + ' open';
+      }
+      else {
+        this.ariaLabel = this.buttonLabel + ' closed';
+      }
+    }
   },
   mounted() {
     document.addEventListener('click', this.handleOutsideClick, false);
@@ -222,7 +236,9 @@ export default {
 
     // Initialize Menu data when Mounted
     this.fetchMenuData();
-  }
+
+    this.updateAriaLabel();
+  },
 };
 </script>
 <style lang="scss">

--- a/@uportal/waffle-menu/src/components/WaffleMenu.vue
+++ b/@uportal/waffle-menu/src/components/WaffleMenu.vue
@@ -215,9 +215,11 @@ export default {
       }
     },
     handleKeyDown(event) {
-      if (event.key === 'Escape') {
+      const menu = this.$refs.waffleMenu;
+      const target = event.target;
+      if (event.key === 'Escape' && this.menuOpen && (menu.contains(target) || event.tagName === 'WAFFLE-MENU' || target.tagName === 'WAFFLE-MENU')) {
         this.toggleMenu();
-        this.$refs.waffleMenu.querySelector('.waffle-trigger').focus();
+        menu.querySelector('.waffle-trigger').focus();
       }
     },
   },

--- a/@uportal/waffle-menu/src/components/WaffleMenu.vue
+++ b/@uportal/waffle-menu/src/components/WaffleMenu.vue
@@ -208,11 +208,19 @@ export default {
       if (menu !== target && !shadow && !menu.contains(target)) {
         this.menuOpen = false;
       }
-    }
+    },
+    handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        this.toggleMenu();
+        this.$refs.waffleMenu.querySelector('.waffle-trigger').focus();
+      }
+    },
   },
   mounted() {
-    // Initialize Menu Date when Mounted
     document.addEventListener('click', this.handleOutsideClick, false);
+    document.addEventListener('keydown', this.handleKeyDown, false);
+
+    // Initialize Menu data when Mounted
     this.fetchMenuData();
   }
 };

--- a/@uportal/waffle-menu/src/components/WaffleMenu.vue
+++ b/@uportal/waffle-menu/src/components/WaffleMenu.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="waffle-menu-container" ref="waffleMenu">
-    <button class="waffle-trigger" @click="toggleMenu()" :aria-label="ariaLabel" :aria-expanded="menuOpen ? 'true' : 'false'">
+    <button
+      class="waffle-trigger"
+      @click="toggleMenu()"
+      :aria-label="ariaLabel"
+      :aria-expanded="menuOpen ? 'true' : 'false'"
+    >
       <FontAwesomeIcon icon="th" :color="buttonColor" size="2x" />
       <div v-if="menuOpen">
         <div class="waffle-triangle-black" />
@@ -76,7 +81,7 @@ export default {
     },
     buttonLabel: {
       type: String,
-      default: 'Waffle Menu',
+      default: 'Waffle Menu'
     },
     menuBackgroundColor: {
       type: String,
@@ -108,7 +113,7 @@ export default {
   data() {
     return {
       menuOpen: false,
-      ariaLabel : this.buttonLabel,
+      ariaLabel: this.buttonLabel,
       data: [],
       dataItems: [],
       dataLoaded: false,
@@ -217,11 +222,17 @@ export default {
     handleKeyDown(event) {
       const menu = this.$refs.waffleMenu;
       const target = event.target;
-      if (event.key === 'Escape' && this.menuOpen && (menu.contains(target) || event.tagName === 'WAFFLE-MENU' || target.tagName === 'WAFFLE-MENU')) {
+      if (
+        event.key === 'Escape' &&
+        this.menuOpen &&
+        (menu.contains(target) ||
+          event.tagName === 'WAFFLE-MENU' ||
+          target.tagName === 'WAFFLE-MENU')
+      ) {
         this.toggleMenu();
         menu.querySelector('.waffle-trigger').focus();
       }
-    },
+    }
   },
   mounted() {
     document.addEventListener('click', this.handleOutsideClick, false);
@@ -229,7 +240,7 @@ export default {
 
     // Initialize Menu data when Mounted
     this.fetchMenuData();
-  },
+  }
 };
 </script>
 <style lang="scss">

--- a/@uportal/waffle-menu/src/components/WaffleMenu.vue
+++ b/@uportal/waffle-menu/src/components/WaffleMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="waffle-menu-container" ref="waffleMenu">
-    <button class="waffle-trigger" @click="toggleMenu()" :aria-label="ariaLabel">
+    <button class="waffle-trigger" @click="toggleMenu()" :aria-label="ariaLabel" :aria-expanded="menuOpen ? 'true' : 'false'">
       <FontAwesomeIcon icon="th" :color="buttonColor" size="2x" />
       <div v-if="menuOpen">
         <div class="waffle-triangle-black" />
@@ -108,7 +108,7 @@ export default {
   data() {
     return {
       menuOpen: false,
-      ariaLabel : this.buttonLabel + ' closed',
+      ariaLabel : this.buttonLabel,
       data: [],
       dataItems: [],
       dataLoaded: false,
@@ -204,7 +204,6 @@ export default {
     // toggle the menu
     toggleMenu() {
       this.menuOpen = !this.menuOpen;
-      this.updateAriaLabel();
     },
     // close the menu if we're clicking outside the menu or trigger
     handleOutsideClick(event) {
@@ -221,14 +220,6 @@ export default {
         this.$refs.waffleMenu.querySelector('.waffle-trigger').focus();
       }
     },
-    updateAriaLabel() {
-      if (this.menuOpen) {
-        this.ariaLabel = this.buttonLabel + ' open';
-      }
-      else {
-        this.ariaLabel = this.buttonLabel + ' closed';
-      }
-    }
   },
   mounted() {
     document.addEventListener('click', this.handleOutsideClick, false);
@@ -236,8 +227,6 @@ export default {
 
     // Initialize Menu data when Mounted
     this.fetchMenuData();
-
-    this.updateAriaLabel();
   },
 };
 </script>


### PR DESCRIPTION
This pull request adds 3 accessibility enhancements

- [x] Pressing `Esc` will close the waffle menu and return focus to the icon
- [x] Added `aria-label` attribute to describe button
- [x] Added `aria-expanded` attribute to indicate if the waffle menu is open or closed