### PR TITLE
fix (esco-favorite-action): favorite data not watched

### DIFF
--- a/@uportal/esco-content-menu/src/components/ActionFavorites.vue
+++ b/@uportal/esco-content-menu/src/components/ActionFavorites.vue
@@ -73,7 +73,7 @@ export default {
       event.preventDefault();
       event.stopPropagation();
       if (!this.debug) {
-        if (this.favorite) {
+        if (this.isFavorite) {
           this.removeFromFavorite();
         } else {
           this.addToFavorite();
@@ -84,7 +84,7 @@ export default {
       return false;
     },
     changeFavoriteValue() {
-      this.favorite = !this.favorite;
+      this.favorite = !this.isFavorite;
       this.$emit('is-favorite', this.favorite);
       this.callOnToggleFav(this.fname);
     },


### PR DESCRIPTION
Use isFavorite function for reactivity as only the prop isFavorite is watched and due to loading order the data favorite is not updated after his init. So the best is to use a computed function that add (automatically) a watcher on the prop and maintain the update.

This commit fix #405 

