### PR TITLE
feat (Content-Carousel):  Configure title and desc to be turned off

### DIFF
--- a/@uportal/content-carousel/README.md
+++ b/@uportal/content-carousel/README.md
@@ -36,7 +36,7 @@ compile 'org.webjars.npm:uportal__content-carousel:{version number goes here}'
 
 ## Usage as Web Component
 
-The component requires a type. It also allows for a `carousel-height` (in rem units), a `fit-to-container` property which causes it to size to its container (horizontally), and `slick-options`.
+The component requires a type. It also allows for a `carousel-height` (in rem units), a `fit-to-container` property which causes it to size to its container (horizontally), `slick-options`, `display-title` to allow or remove the title from the 'alt text' and caption bar, and `display-description` to allow or remove the description from the 'alt text' and caption bar.
 
 ```html
 <link
@@ -52,6 +52,8 @@ The component requires a type. It also allows for a `carousel-height` (in rem un
   slick-options='{ "slidesToShow": 1, "infinite": true, "arrows": true }'
   carousel-height="30rem"
   fit-to-container="true"
+  display-title="true"
+  display-description="true"
 >
 </content-carousel>
 ```
@@ -63,6 +65,8 @@ The component requires a type. It also allows for a `carousel-height` (in rem un
 - `slick-options` (optional, [slick settings](https://kenwheeler.github.io/slick/#settings)): configuration for slick carousel.
 - `carousel-height` (optional, string): css height to apply on slides.
 - `fit-to-container` (optional, boolean): by default carousel will fit content, `true` will make carousel match width of surrounding container.
+- `display-title` (optional, boolean): Current implemented for the RSS Strategy. By default carousel will show the title in the 'alt text' and the caption bar. Setting to `false` will remove the title from the 'alt text' and the caption bar.
+- `display-description` (optional, boolean): Current implemented for the RSS Strategy. By default carousel will show the description in the 'alt text' and the caption bar. Setting to `false` will remove the description from the 'alt text' and the caption bar. Note - if BOTH `display-title` and `display-description` are `false`, the caption bar will be hidden.
 
 ### Types
 

--- a/@uportal/content-carousel/src/components/ContentCarousel.ts
+++ b/@uportal/content-carousel/src/components/ContentCarousel.ts
@@ -62,6 +62,12 @@ export default class ContentCarousel extends Vue {
   @Prop({type: [String], default: ''})
   public theme?: string;
 
+  @Prop({type: Boolean, default: true})
+  public displayTitle!: boolean;
+
+  @Prop({type: Boolean, default: true})
+  public displayDescription!: boolean;
+
   public strategy: DataStrategy = {
     items: [] as CarouselItem[],
   } as DataStrategy;
@@ -93,7 +99,7 @@ export default class ContentCarousel extends Vue {
 
     switch (this.type.toLowerCase()) {
       case 'rss': {
-        this.strategy = new RssStrategy(this.source);
+        this.strategy = new RssStrategy(this.source, this.displayTitle, this.displayDescription);
         break;
       }
       case 'portlet': {

--- a/@uportal/content-carousel/src/lib/RssStrategy.ts
+++ b/@uportal/content-carousel/src/lib/RssStrategy.ts
@@ -7,7 +7,12 @@ export class RssStrategy implements DataStrategy {
 
   public items: CarouselItem[] = [];
 
-  constructor(public feed: string) {
+  private displayTitle: boolean;
+  private displayDescription: boolean;
+
+  constructor(public feed: string, displayTitle: boolean, displayDescription: boolean) {
+    this.displayTitle = displayTitle;
+    this.displayDescription = displayDescription;
     this.load(feed);
   }
 
@@ -18,7 +23,7 @@ export class RssStrategy implements DataStrategy {
     }
     const feed = await response.text();
 
-    const {items} = await parseXml(feed);
+    const {items} = await parseXml(feed, this.displayTitle, this.displayDescription);
     this.items = items.map(
         (
             {

--- a/@uportal/content-carousel/src/lib/parse.ts
+++ b/@uportal/content-carousel/src/lib/parse.ts
@@ -1,7 +1,7 @@
 import * as util from 'util';
 import {parseString} from 'xml2js';
 
-function convert(json: any): any {
+function convert(json: any, displayTitle = true, displayDescription = true): any {
   let channel = json.rss.channel;
   const rss: { items: any[]; [propName: string]: any } = {items: []};
   if (Array.isArray(json.rss.channel)) {
@@ -30,9 +30,11 @@ function convert(json: any): any {
     }
     channel.item.forEach((val: any) => {
       const obj = {} as any;
-      obj.title = !util.isNullOrUndefined(val.title) ? val.title[0] : '';
+      obj.title = !util.isNullOrUndefined(val.title)
+        ? (displayTitle ? val.title[0] : '')
+        : '';
       obj.description = !util.isNullOrUndefined(val.description)
-        ? val.description[0]
+        ? (displayDescription ? val.description[0] : '')
         : '';
       obj.url = obj.link = !util.isNullOrUndefined(val.link) ? val.link[0] : '';
 
@@ -67,13 +69,13 @@ function convert(json: any): any {
   return rss;
 }
 
-export function parseXml(xml: string): Promise<any> {
+export function parseXml(xml: string, displayTitle = true, displayDescription = true): Promise<any> {
   return new Promise((resolve, reject) => {
     parseString(xml, (err, result) => {
       if (err) {
         reject(err);
       } else {
-        resolve(convert(result));
+        resolve(convert(result, displayTitle, displayDescription));
       }
     });
   });


### PR DESCRIPTION
Enables two new component parameters for RSS Strategy.

`display-title` & `display-description` - by default carousel will show the text in the 'alt text' and the caption bar. Setting to `false` will remove the text from the 'alt text' and the caption bar.

 Note - if BOTH `display-title` and `display-description` are `false`, the caption bar will be hidden.