### PR TITLE
[WIP] fix(esco-content-menu): accessibility improvements

### DIFF
--- a/@uportal/esco-content-menu/src/components/ActionFavorites.vue
+++ b/@uportal/esco-content-menu/src/components/ActionFavorites.vue
@@ -159,7 +159,6 @@ export default {
     text-transform: uppercase;
     text-decoration: none;
     border: none;
-    outline: none;
     background-color: transparent;
     box-shadow: none;
     cursor: pointer;

--- a/@uportal/esco-content-menu/src/components/ActionFavorites.vue
+++ b/@uportal/esco-content-menu/src/components/ActionFavorites.vue
@@ -56,6 +56,7 @@ export default {
     fname: {type: String, required: true},
     isFavorite: {type: Boolean, default: false},
     backGroundIsDark: {type: Boolean, default: false},
+    portletDesc: {type: Object, required: true},
   },
   data() {
     return {
@@ -66,7 +67,7 @@ export default {
     favoriteMessage() {
       return this.translate(
         this.isFavorite ? 'message.favorites.remove' : 'message.favorites.add'
-      );
+      ).replace('{}', this.portletDesc.title);
     },
   },
   methods: {

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -46,7 +46,9 @@
           </div>
         </slot>
       </div>
-      <div class="status sr-only" aria-live="polite">{{ statusMsg }}</div>
+      <div
+        class="status sr-only"
+        aria-live="polite">{{ statusMsg }}</div>
       <div class="flex-grid">
         <div
           v-for="portlet in filteredPortlets"
@@ -300,8 +302,11 @@ export default {
       const portlet = portlets.filter(function(p) {
         return p.fname === fname;
       });
-      this.statusMsg = this.translate(this.isFavorite(fname) ? 'message.favorites.added' : 'message.favorites.removed')
-          .replace('{}', portlet[0].title);
+      this.statusMsg = this.translate(
+        this.isFavorite(fname)
+          ? 'message.favorites.added'
+          : 'message.favorites.removed'
+      ).replace('{}', portlet[0].title);
     },
     setFilterCategory(e) {
       this.filterCategory = e.detail || '';
@@ -322,6 +327,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import './../styles/common.scss';
+
 $searchSize: 32px;
 
 .content-grid {

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -46,31 +46,24 @@
           </div>
         </slot>
       </div>
+      <div class="status sr-only" aria-live="polite">{{ statusMsg }}</div>
       <div class="flex-grid">
         <div
           v-for="portlet in filteredPortlets"
           :key="portlet.id"
           :class="['portlet-card-' + _portletCardSize]"
           class="flex-item ma-3 text-xs-center">
-          <a
-            :href="getRenderPortletUrl(portlet)"
-            :target="hasAlternativeMaximizedUrl(portlet) ? '_blank' : '_self'"
-            :rel="
-              hasAlternativeMaximizedUrl(portlet) ? 'noopener noreferrer' : ''
-            "
-            class="no-style">
-            <portlet-card
-              :messages="messages"
-              :portlet-desc="portlet"
-              :is-favorite="isFavorite(portlet.fname)"
-              :size="_portletCardSize"
-              :hide-action="hideAction"
-              :call-after-action="actionToggleFav"
-              :favorite-api-url="favoriteApiUrl"
-              :user-info-api-url="userInfoApiUrl"
-              :back-ground-is-dark="portletBackgroundIsDark"
-              :debug="debug"/>
-          </a>
+          <portlet-card
+            :messages="messages"
+            :portlet-desc="portlet"
+            :is-favorite="isFavorite(portlet.fname)"
+            :size="_portletCardSize"
+            :hide-action="hideAction"
+            :call-after-action="actionToggleFav"
+            :favorite-api-url="favoriteApiUrl"
+            :user-info-api-url="userInfoApiUrl"
+            :back-ground-is-dark="portletBackgroundIsDark"
+            :debug="debug"/>
         </div>
       </div>
       <slot name="footer">
@@ -111,10 +104,6 @@ import {
   breakPointName,
   sizeValidator,
 } from '../services/sizeTools';
-import {
-  hasAlternativeMaximizedUrl,
-  getRenderUrl,
-} from '../services/managePortletUrl';
 import matchSorter from 'match-sorter';
 
 export default {
@@ -183,6 +172,7 @@ export default {
       elementSize: this.parentScreenSize,
       localPortlets: [],
       localFavorites: [],
+      statusMsg: '',
     };
   },
   computed: {
@@ -260,12 +250,6 @@ export default {
     window.removeEventListener('resize', this.calculateSize);
   },
   methods: {
-    hasAlternativeMaximizedUrl(portletDesc) {
-      return hasAlternativeMaximizedUrl(portletDesc);
-    },
-    getRenderPortletUrl(portletDesc) {
-      return getRenderUrl(portletDesc, this.contextApiUrl);
-    },
     isFavorite(fname) {
       const favorites = this.favorites || this.localFavorites;
       return favorites.includes(fname);
@@ -311,6 +295,13 @@ export default {
       if (!this.favorites) {
         this.localFavorites = toggleArray(this.localFavorites, fname);
       }
+
+      const portlets = this.portlets || this.localPortlets;
+      const portlet = portlets.filter(function(p) {
+        return p.fname === fname;
+      });
+      this.statusMsg = this.translate(this.isFavorite(fname) ? 'message.favorites.added' : 'message.favorites.removed')
+          .replace('{}', portlet[0].title);
     },
     setFilterCategory(e) {
       this.filterCategory = e.detail || '';
@@ -499,6 +490,7 @@ $searchSize: 32px;
         margin: 20px auto;
         margin: var(--content-griditem-margin, 20px auto);
         padding: 0 2.5px;
+        position: relative;
       }
 
       /** fix IE flexbox bug on margin auto https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14593426/. */

--- a/@uportal/esco-content-menu/src/components/PortletCard.vue
+++ b/@uportal/esco-content-menu/src/components/PortletCard.vue
@@ -14,7 +14,7 @@
           <img
             :src="iconUrl"
             alt=""
-            role="presentation">
+            role="presentation" >
         </div>
         <div
           v-else
@@ -71,6 +71,10 @@ export default {
   },
   props: {
     callAfterAction: {type: Function, default: () => {}},
+    contextApiUrl: {
+      type: String,
+      default: process.env.VUE_APP_PORTAL_CONTEXT,
+    },
     cssClass: {type: String, default: 'portlet-card'},
     // Background is needed if your icons doesn't have it integrated
     iconBackgroundColor: {type: String, default: 'Transparent'},
@@ -176,7 +180,7 @@ export default {
     display: flex;
     flex-flow: column nowrap;
     text-decoration: none;
-    
+
     /* prettier-ignore */
     box-shadow:
       0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/@uportal/esco-content-menu/src/components/PortletCard.vue
+++ b/@uportal/esco-content-menu/src/components/PortletCard.vue
@@ -1,29 +1,37 @@
 <template>
   <div :class="mainClass">
-    <div class="portlet-card-icon">
-      <div
-        v-if="iconUrl !== null"
-        :style="'background-color:' + iconBackgroundColor"
-        class="img-wrapper">
-        <img
-          :src="iconUrl"
-          :alt="title" >
+    <a
+      :href="getRenderPortletUrl(portletDesc)"
+      :target="hasAlternativeMaximizedUrl(portletDesc) ? '_blank' : '_self'"
+      :rel="
+        hasAlternativeMaximizedUrl(portletDesc) ? 'noopener noreferrer' : ''
+      ">
+      <div class="portlet-card-icon">
+        <div
+          v-if="iconUrl !== null"
+          :style="'background-color:' + iconBackgroundColor"
+          class="img-wrapper">
+          <img
+            :src="iconUrl"
+            alt=""
+            role="presentation">
+        </div>
+        <div
+          v-else
+          :style="'background-color:' + iconBackgroundColor"
+          class="img-wrapper"/>
       </div>
-      <div
-        v-else
-        :style="'background-color:' + iconBackgroundColor"
-        class="img-wrapper"/>
-    </div>
-    <div class="portlet-card-title">
-      {{ title }}
-    </div>
-    <div class="portlet-card-description">
-      <ellipsis
-        v-if="append"
-        :message="truncate(description)"
-        :line-height="'20px'"
-        :end-char="'...'"/>
-    </div>
+      <div class="portlet-card-title">
+        {{ title }}
+      </div>
+      <div class="portlet-card-description">
+        <ellipsis
+          v-if="append"
+          :message="truncate(description)"
+          :line-height="'20px'"
+          :end-char="'...'"/>
+      </div>
+    </a>
     <div
       v-if="!hideAction"
       class="portlet-card-action">
@@ -37,7 +45,8 @@
         :favorite-api-url="favoriteApiUrl"
         :user-info-api-url="userInfoApiUrl"
         :back-ground-is-dark="favBgIsDark"
-        :debug="debug"/>
+        :debug="debug"
+        :portlet-desc="portletDesc"/>
     </div>
   </div>
 </template>
@@ -48,6 +57,10 @@ import i18nMixin from '../mixins/i18n.js';
 import ActionFavorites from './ActionFavorites';
 import {sizeValidator} from '../services/sizeTools';
 import computeUrl from '../services/computeUrl';
+import {
+  hasAlternativeMaximizedUrl,
+  getRenderUrl,
+} from '../services/managePortletUrl';
 
 export default {
   name: 'PortletCard',
@@ -129,6 +142,12 @@ export default {
     },
   },
   methods: {
+    hasAlternativeMaximizedUrl(portletDesc) {
+      return hasAlternativeMaximizedUrl(portletDesc);
+    },
+    getRenderPortletUrl(portletDesc) {
+      return getRenderUrl(portletDesc, this.contextApiUrl);
+    },
     truncate(entry) {
       if (entry) {
         const text = entry.split('   ');
@@ -145,196 +164,199 @@ export default {
 @import './../styles/vars.scss';
 
 .portlet-card {
-  width: $PortletCardSizeLarge;
-  height: 170px;
-  padding: 5px;
-  line-height: 20px;
-  background-color: white;
-  text-align: center;
-  border-radius: 5px;
-  position: relative;
-  display: flex;
-  flex-flow: column nowrap;
-
-  /* prettier-ignore */
-  box-shadow:
-    0 2px 2px 0 rgba(0, 0, 0, 0.14),
-    0 3px 1px -2px rgba(0, 0, 0, 0.12),
-    0 1px 5px 0 rgba(0, 0, 0, 0.2);
-  transition: box-shadow 0.25s;
-
-  &:hover {
-    cursor: pointer;
-
+  a {
+    width: $PortletCardSizeLarge;
+    height: 170px;
+    padding: 5px;
+    line-height: 20px;
+    background-color: white;
+    text-align: center;
+    border-radius: 5px;
+    position: relative;
+    display: flex;
+    flex-flow: column nowrap;
+    text-decoration: none;
+    
     /* prettier-ignore */
     box-shadow:
-      0 7px 8px -4px rgba(0, 0, 0, 0.2),
-      0 12px 17px 2px rgba(0, 0, 0, 0.14),
-      0 5px 22px 4px rgba(0, 0, 0, 0.12);
+      0 2px 2px 0 rgba(0, 0, 0, 0.14),
+      0 3px 1px -2px rgba(0, 0, 0, 0.12),
+      0 1px 5px 0 rgba(0, 0, 0, 0.2);
+    transition: box-shadow 0.25s;
+
+    &:hover {
+      cursor: pointer;
+
+      /* prettier-ignore */
+      box-shadow:
+        0 7px 8px -4px rgba(0, 0, 0, 0.2),
+        0 12px 17px 2px rgba(0, 0, 0, 0.14),
+        0 5px 22px 4px rgba(0, 0, 0, 0.12);
+    }
+
+    > .portlet-card-icon,
+    > .portlet-card-title,
+    > .portlet-card-description {
+      display: block;
+      text-align: center;
+      color: rgba(0, 0, 0, 0.8);
+    }
+
+    > .portlet-card-icon {
+      display: var(--content-gridcard-icon-display);
+
+      > div {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 83px;
+        width: 83px;
+        margin-top: -30px;
+        border-radius: 10px;
+
+        img {
+          height: 100%;
+          width: auto;
+          border-radius: 10px;
+        }
+      }
+    }
+
+    > .portlet-card-title {
+      display: var(--content-gridcard-title-display);
+      padding-top: 1em;
+      font-size: 16px;
+      font-weight: bold;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    > .portlet-card-description {
+      display: var(--content-gridcard-description-display);
+      padding-top: 0.3em;
+      flex: 1;
+      font-size: 14px;
+    }
+
+    &.custom-card {
+      padding: 5px;
+      padding: var(--content-gridcard-padding, 5px);
+      border: none;
+      border: var(--content-gridcard-border, none);
+      background-color: white;
+      background-color: var(--content-gridcard-bg-color, white);
+      border-radius: 5px;
+      border-radius: var(--content-gridcard-border-radius, 5px);
+      box-shadow: none;
+      box-shadow: var(--content-gridcard-shadow, none);
+      transition: box-shadow 0.25s;
+      width: $PortletCardSizeCustomWidth;
+      width: var(--content-gridcard-size-w, $PortletCardSizeCustomWidth);
+      height: $PortletCardSizeCustomHeight;
+      height: var(--content-gridcard-size-h, $PortletCardSizeCustomHeight);
+
+      &:hover {
+        box-shadow: none;
+        box-shadow: var(--content-gridcard-shadow-hover, none);
+      }
+
+      & > .portlet-card-icon {
+        > div {
+          height: 75px;
+          height: var(--content-gridcard-icon-size, 75px);
+          width: 75px;
+          width: var(--content-gridcard-icon-size, 75px);
+          margin-top: 0;
+        }
+      }
+
+      > .portlet-card-title {
+        overflow-x: hidden;
+        overflow-y: visible;
+        text-overflow: ellipsis;
+        font-size: var(--content-gridcard-title-fontsize, 16px);
+      }
+
+      > .portlet-card-description {
+        font-size: var(--content-gridcard-description-fontsize, 16px);
+      }
+    }
+
+    &.medium-card,
+    &.small-card,
+    &.smaller-card {
+      height: 160px;
+
+      > .portlet-card-icon {
+        > div {
+          height: 75px;
+          width: 75px;
+        }
+      }
+    }
+
+    &.small-card,
+    &.smaller-card {
+      height: auto;
+      background-color: transparent;
+      border: none;
+      box-shadow: none;
+      padding: 0;
+
+      &.background-dark {
+        > .portlet-card-title,
+        > .portlet-card-description {
+          color: white;
+        }
+      }
+
+      > .portlet-card-description {
+        display: none;
+      }
+
+      > .portlet-card-icon {
+        > div {
+          margin: 0;
+        }
+      }
+
+      > .portlet-card-title {
+        padding-top: 0.8em;
+        font-weight: 500;
+      }
+
+      > .portlet-card-action {
+        margin: 0;
+      }
+
+      &:not(.hide-action) {
+        margin-top: $PortletCardButtonSize / 2;
+
+        > .portlet-card-action {
+          top: $PortletCardButtonSize - (($PortletCardButtonSize / 2) * 3);
+        }
+      }
+    }
+
+    &.medium-card {
+      width: $PortletCardSizeMedium;
+    }
+
+    &.small-card {
+      width: $PortletCardSizeSmall;
+    }
+
+    &.smaller-card {
+      width: $PortletCardSizeSmaller;
+    }
   }
 
-  > .portlet-card-icon,
-  > .portlet-card-title,
-  > .portlet-card-description {
-    display: block;
-    text-align: center;
-    color: rgba(0, 0, 0, 0.8);
-  }
-
-  > .portlet-card-action {
+  .portlet-card-action {
     color: rgba(0, 0, 0, 0.34);
     position: absolute;
     top: 0;
     right: 0;
     margin: 5px;
-  }
-
-  > .portlet-card-icon {
-    display: var(--content-gridcard-icon-display);
-
-    > div {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      height: 83px;
-      width: 83px;
-      margin-top: -30px;
-      border-radius: 10px;
-
-      img {
-        height: 100%;
-        width: auto;
-        border-radius: 10px;
-      }
-    }
-  }
-
-  > .portlet-card-title {
-    display: var(--content-gridcard-title-display);
-    padding-top: 1em;
-    font-size: 16px;
-    font-weight: bold;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  > .portlet-card-description {
-    display: var(--content-gridcard-description-display);
-    padding-top: 0.3em;
-    flex: 1;
-    font-size: 14px;
-  }
-
-  &.custom-card {
-    padding: 5px;
-    padding: var(--content-gridcard-padding, 5px);
-    border: none;
-    border: var(--content-gridcard-border, none);
-    background-color: white;
-    background-color: var(--content-gridcard-bg-color, white);
-    border-radius: 5px;
-    border-radius: var(--content-gridcard-border-radius, 5px);
-    box-shadow: none;
-    box-shadow: var(--content-gridcard-shadow, none);
-    transition: box-shadow 0.25s;
-    width: $PortletCardSizeCustomWidth;
-    width: var(--content-gridcard-size-w, $PortletCardSizeCustomWidth);
-    height: $PortletCardSizeCustomHeight;
-    height: var(--content-gridcard-size-h, $PortletCardSizeCustomHeight);
-
-    &:hover {
-      box-shadow: none;
-      box-shadow: var(--content-gridcard-shadow-hover, none);
-    }
-
-    & > .portlet-card-icon {
-      > div {
-        height: 75px;
-        height: var(--content-gridcard-icon-size, 75px);
-        width: 75px;
-        width: var(--content-gridcard-icon-size, 75px);
-        margin-top: 0;
-      }
-    }
-
-    > .portlet-card-title {
-      overflow-x: hidden;
-      overflow-y: visible;
-      text-overflow: ellipsis;
-      font-size: var(--content-gridcard-title-fontsize, 16px);
-    }
-
-    > .portlet-card-description {
-      font-size: var(--content-gridcard-description-fontsize, 16px);
-    }
-  }
-
-  &.medium-card,
-  &.small-card,
-  &.smaller-card {
-    height: 160px;
-
-    > .portlet-card-icon {
-      > div {
-        height: 75px;
-        width: 75px;
-      }
-    }
-  }
-
-  &.small-card,
-  &.smaller-card {
-    height: auto;
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
-    padding: 0;
-
-    &.background-dark {
-      > .portlet-card-title,
-      > .portlet-card-description {
-        color: white;
-      }
-    }
-
-    > .portlet-card-description {
-      display: none;
-    }
-
-    > .portlet-card-icon {
-      > div {
-        margin: 0;
-      }
-    }
-
-    > .portlet-card-title {
-      padding-top: 0.8em;
-      font-weight: 500;
-    }
-
-    > .portlet-card-action {
-      margin: 0;
-    }
-
-    &:not(.hide-action) {
-      margin-top: $PortletCardButtonSize / 2;
-
-      > .portlet-card-action {
-        top: $PortletCardButtonSize - (($PortletCardButtonSize / 2) * 3);
-      }
-    }
-  }
-
-  &.medium-card {
-    width: $PortletCardSizeMedium;
-  }
-
-  &.small-card {
-    width: $PortletCardSizeSmall;
-  }
-
-  &.smaller-card {
-    width: $PortletCardSizeSmaller;
   }
 }
 </style>

--- a/@uportal/esco-content-menu/src/locales/en-US.json
+++ b/@uportal/esco-content-menu/src/locales/en-US.json
@@ -5,8 +5,10 @@
       "filter": "Find a service..."
     },
     "favorites": {
-      "add": "Add to favorites",
-      "remove": "Remove from favorites",
+      "add": "Add \"{}\" to favorites",
+      "added": "\"{}\" has been added to your favorites",
+      "remove": "Remove \"{}\" from favorites",
+      "removed": "\"{}\" has been removed from your favorites",
       "title": "My Favorites",
       "empty": "No favorite defined"
     },

--- a/@uportal/esco-content-menu/src/locales/en.json
+++ b/@uportal/esco-content-menu/src/locales/en.json
@@ -5,8 +5,10 @@
       "filter": "Find a service..."
     },
     "favorites": {
-      "add": "Add to favorites",
-      "remove": "Remove from favorites",
+      "add": "Add \"{}\" to favorites",
+      "added": "\"{}\" has been added to your favorites",
+      "remove": "Remove \"{}\" from favorites",
+      "removed": "\"{}\" has been removed from your favorites",
       "title": "My Favorites",
       "empty": "No favorite defined"
     },

--- a/@uportal/esco-content-menu/src/locales/fr-FR.json
+++ b/@uportal/esco-content-menu/src/locales/fr-FR.json
@@ -5,8 +5,8 @@
       "filter": "Rechercher un service..."
     },
     "favorites": {
-      "add": "Ajouter aux favoris",
-      "remove": "Supprimer des favoris",
+      "add": "Ajouter \"{}\" aux favoris",
+      "remove": "Supprimer \"{}\" des favoris",
       "title": "Mes favoris",
       "empty": "Aucun favori défini"
     },

--- a/@uportal/esco-content-menu/src/locales/fr.json
+++ b/@uportal/esco-content-menu/src/locales/fr.json
@@ -5,8 +5,10 @@
       "filter": "Rechercher un service..."
     },
     "favorites": {
-      "add": "Ajouter aux favoris",
-      "remove": "Supprimer des favoris",
+      "add": "Ajouter \"{}\" aux favoris",
+      "added": "\"{}\" a été ajouté à vos favoris",
+      "remove": "Supprimer \"{}\" des favoris",
+      "removed": "\"{}\" a été retiré de vos favoris",
       "title": "Mes favoris",
       "empty": "Aucun favori défini"
     },


### PR DESCRIPTION
We've made various tweaks to the content grid to improve accessibility

- added an aria-live region to announce when a portlet is added/removed from favorites
- slightly restructured the element such that the favorite button isn't part of the `a` element
- removed a CSS rule that removed the outline on the favorite button as a focus indicator wouldn't be shown in chrome

supersedes PR #428 
resolves issue #431 
resolves issue #438