### PR TITLE
feat(content-carousel):  CSS var to control the display of the hero text

### DIFF
--- a/@uportal/content-carousel/README.md
+++ b/@uportal/content-carousel/README.md
@@ -70,7 +70,7 @@ Currently this component supports CSS Variables for the following abilities. Def
 
 You should define this in your custom stylesheet.
 
-```
+```css
 :root {
   --cc-hero-text-display: block; // Affects the grey bar at the bottom of slides.  Default is 'block'.
 }

--- a/@uportal/content-carousel/README.md
+++ b/@uportal/content-carousel/README.md
@@ -64,6 +64,18 @@ The component requires a type. It also allows for a `carousel-height` (in rem un
 - `carousel-height` (optional, string): css height to apply on slides.
 - `fit-to-container` (optional, boolean): by default carousel will fit content, `true` will make carousel match width of surrounding container.
 
+### Theming
+
+Currently this component supports CSS Variables for the following abilities. Defining the following variables will change the function for the component accordingly. They will fall back to the default behavior described below.
+
+You should define this in your custom stylesheet.
+
+```
+:root {
+  --cc-hero-text-display: block; // Affects the grey bar at the bottom of slides.  Default is 'block'.
+}
+```
+
 ### Types
 
 There are three data source types currently supported RSS, Portlet, and Passthrough.

--- a/@uportal/content-carousel/src/components/ContentCarousel.scss
+++ b/@uportal/content-carousel/src/components/ContentCarousel.scss
@@ -113,6 +113,7 @@
       bottom: 0;
       background: rgba(0, 0, 0, 0.5);
       color: white;
+      display: block;
       display: var(--cc-hero-text-display, block);
 
       p {

--- a/@uportal/content-carousel/src/components/ContentCarousel.scss
+++ b/@uportal/content-carousel/src/components/ContentCarousel.scss
@@ -113,6 +113,7 @@
       bottom: 0;
       background: rgba(0, 0, 0, 0.5);
       color: white;
+      display: var(--cc-hero-text-display, block);
 
       p {
         padding: 10px;
@@ -164,8 +165,6 @@
       border-bottom: none;
       border-bottom: var(--cc-description-border-bottom, none);
       display: block;
-    }
-    &.has-description .slick-item-description {
       display: var(--cc-description-display, block);
     }
     &.has-image .slick-image {


### PR DESCRIPTION
Replaces PR #436 

Uses a CSS variable to control the display of the grey hero text banner at the bottom of slides.

Note:  IE is not honoring the CSS variable.

#438 and #439 found while testing this change.
