### PR TITLE
fix(dashboard-carousel): added max-width & margin-bottom rules for mobile viewports

### DIFF
--- a/@uportal/dashboard-carousel/src/components/Carousel.vue
+++ b/@uportal/dashboard-carousel/src/components/Carousel.vue
@@ -310,11 +310,18 @@ ul {
 
 /* Small devices (landscape phones, less than 768px) */
 @media (max-width: 767.98px) {
-  .slick-item {
-    flex-direction: column;
+  .carousel /deep/ {
+    .slick-item {
+      flex-direction: column;
 
-    & > span {
-      max-width: none;
+      > div {
+        max-width: none;
+        margin-bottom: 10px;
+      }
+
+      & > span {
+        max-width: none;
+      }
     }
   }
 


### PR DESCRIPTION
Presently, when viewing the dashboard carousel in a mobile viewport, it renders as follows:
![Screen Shot 2019-09-27 at 09 20 52](https://user-images.githubusercontent.com/41875/65785193-aeca6b00-e108-11e9-9663-0b64279c8efb.png)
![Screen Shot 2019-09-27 at 09 33 01](https://user-images.githubusercontent.com/41875/65785681-d66e0300-e109-11e9-80a6-8d34feeaa8cc.png)

This PR sets the `max-width` of the div inside `slick-item` to its initial value of `none` and adds a `bottom-margin` of `10px` such that it renders as such
![Screen Shot 2019-09-27 at 09 20 57](https://user-images.githubusercontent.com/41875/65785172-a2dea900-e108-11e9-9f25-34ed2b593d95.png)
![Screen Shot 2019-09-27 at 09 32 16](https://user-images.githubusercontent.com/41875/65785649-bdfde880-e109-11e9-9637-6ac4b8ddb7ec.png)

Let me know if I missed anything and/or if there are any use cases that need to be considered.
