### PR TITLE
fix(esco-content-menu): style favorite sr-only

### DIFF
--- a/@uportal/esco-content-menu/src/components/ActionFavorites.vue
+++ b/@uportal/esco-content-menu/src/components/ActionFavorites.vue
@@ -143,6 +143,7 @@ export default {
 
 <style lang="scss" scoped>
 @import './../styles/vars.scss';
+@import './../styles/common.scss';
 
 .action-favorites {
   &.background-dark {

--- a/@uportal/esco-content-menu/src/styles/common.scss
+++ b/@uportal/esco-content-menu/src/styles/common.scss
@@ -1,0 +1,10 @@
+.sr-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}


### PR DESCRIPTION
provide a sr-only class that isn't applied on builded components.

fix #438 