### PR TITLE
feat(esco-content-grid): add preamble slot

### DIFF
--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -341,6 +341,21 @@ The `header-right` slot permit to apply a custom title replacing the default fil
 </content-grid>
 ```
 
+##### Preamble
+
+The `preamble` slot permit to add descriptive text between the headers and grid. As example:
+
+```html
+<content-grid
+  background-color="grey"
+  portlet-card-size="medium"
+  portlet-api-url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=administration"
+  layout-api-url="..."
+>
+  <div slot="preamble">This is explanatory text for the grid.</div>
+</content-grid>
+```
+
 ##### Footer
 
 The `footer` slot permit to apply a custom title replacing the default filter on footer. As example:

--- a/@uportal/esco-content-menu/package-lock.json
+++ b/@uportal/esco-content-menu/package-lock.json
@@ -1154,6 +1154,14 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
     },
+    "@uportal/open-id-connect": {
+      "version": "1.33.2",
+      "resolved": "https://registry.npmjs.org/@uportal/open-id-connect/-/open-id-connect-1.33.2.tgz",
+      "integrity": "sha512-slkqcRm124BnWLw71wv2y7DFsFlH39GL8cxB/Jp2C6zgX0mhtLTfTjfQVh/TppxI24lJq60x05y1FapPCDCiCg==",
+      "requires": {
+        "jwt-decode": "^2.2.0"
+      }
+    },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.0.0.tgz",
@@ -7050,6 +7058,11 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
     },
     "killable": {
       "version": "1.0.1",

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -43,6 +43,9 @@
           </div>
         </slot>
       </div>
+      <div class="preamble">
+        <slot name="preamble" class="preamble" />
+      </div>
       <div class="flex-grid">
         <div
           v-for="portlet in filteredPortlets"
@@ -488,6 +491,12 @@ $searchSize: 32px;
           display: none;
         }
       }
+    }
+
+    .preamble {
+      display: flex;
+      flex-flow: row wrap;
+      padding: 0 20px;
     }
 
     .flex-grid {


### PR DESCRIPTION
Add "preamble" div between headers and grid for explanatory text.

Implemented with a slot. Styling and doc updated.