### PR TITLE
fix(sidebar-nav): update build in package.json to correct name of tag

### DIFF
--- a/@uportal/sidebar-nav/package.json
+++ b/@uportal/sidebar-nav/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "prebuild": "babel node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js -o node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js",
-    "build": "vue-cli-service build --name sidebar-nav --target wc \"src/components/*.vue\"",
+    "build": "vue-cli-service build --name sidebar-nav --target wc \"src/components/SidebarNav.vue\"",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
Due to '*' in build script, web component tag was `<sidebar-nav-sidebar-nav>`. Specifying the component, corrects the expected tag name to `<sidebar-nav>`